### PR TITLE
Enable navigate IPC event

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -68,7 +68,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'nest-updated',
             'nests-data-updated',
             'activate-status-tab',
-            'redeem-code-result'
+            'redeem-code-result',
+            'navigate'
         ];
         if (validChannels.includes(channel)) {
             console.log(`Registrando listener para o canal: ${channel}`);


### PR DESCRIPTION
## Summary
- allow renderer to listen for the `navigate` IPC event

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686efa6601e0832abd778b0e1af30890