### PR TITLE
Add base path to Vite config

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- configure Vite with `base: './'`

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build --prefix frontend` *(fails: vite not found)*
- `npm start` *(fails: electron not found)*

------
https://chatgpt.com/codex/tasks/task_e_686efdc33134832aa10b7a6861213123