### PR TITLE
Implement fullscreen home screen

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,47 @@
+html, body, #root {
+  height: 100%;
+  margin: 0;
+}
+
+.home-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}
+
+.home-button {
+  margin: 8px 0;
+  padding: 12px 24px;
+  font-size: 1.2rem;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal-content {
+  background: white;
+  padding: 20px;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.volume-control {
+  display: flex;
+  align-items: center;
+  margin: 12px 0;
+}
+
+.volume-control input {
+  margin: 0 8px;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,12 +1,9 @@
 import React from 'react'
 import HomeScreen from './components/HomeScreen'
-import LoadPet from './components/LoadPet'
+import './App.css'
 
 export default function App() {
   return (
-    <div>
-      <HomeScreen />
-      <LoadPet />
-    </div>
+    <HomeScreen />
   )
 }

--- a/frontend/src/components/HomeScreen.jsx
+++ b/frontend/src/components/HomeScreen.jsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react'
+
+export default function HomeScreen() {
+  const [showExit, setShowExit] = useState(false)
+  const [showOptions, setShowOptions] = useState(false)
+  const [language, setLanguage] = useState('pt')
+  const [volume, setVolume] = useState(50)
+
+  const quit = () => {
+    if (window.api?.quit) {
+      window.api.quit()
+    } else {
+      window.close()
+    }
+  }
+
+  return (
+    <div className="home-container">
+      <button className="home-button">Iniciar</button>
+      <button className="home-button" onClick={() => setShowOptions(true)}>Opções</button>
+      <button className="home-button" onClick={() => setShowExit(true)}>Sair</button>
+
+      {showExit && (
+        <div className="modal">
+          <div className="modal-content">
+            <p>Deseja mesmo sair do jogo?</p>
+            <button onClick={quit}>Sim</button>
+            <button onClick={() => setShowExit(false)}>Não</button>
+          </div>
+        </div>
+      )}
+
+      {showOptions && (
+        <div className="modal">
+          <div className="modal-content">
+            <div>
+              <label>
+                <input type="radio" value="pt" checked={language === 'pt'} onChange={() => setLanguage('pt')} />
+                Português
+              </label>
+              <label>
+                <input type="radio" value="en" checked={language === 'en'} onChange={() => setLanguage('en')} />
+                Inglês
+              </label>
+            </div>
+            <div className="volume-control">
+              <span role="img" aria-label="muted">🔇</span>
+              <input
+                type="range"
+                min="1"
+                max="100"
+                value={volume}
+                onChange={(e) => setVolume(e.target.value)}
+              />
+              <span role="img" aria-label="sound">🔊</span>
+            </div>
+            <button onClick={() => setShowOptions(false)}>Fechar</button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/main.js
+++ b/main.js
@@ -1,10 +1,9 @@
-const { app, BrowserWindow } = require('electron')
+const { app, BrowserWindow, ipcMain } = require('electron')
 const path = require('path')
 
 function createWindow() {
   const win = new BrowserWindow({
-    width: 800,
-    height: 600,
+    fullscreen: true,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js')
     }
@@ -23,6 +22,10 @@ app.whenReady().then(() => {
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
   })
+})
+
+ipcMain.on('quit-app', () => {
+  app.quit()
 })
 
 app.on('window-all-closed', () => {

--- a/preload.js
+++ b/preload.js
@@ -1,2 +1,6 @@
-const { contextBridge } = require('electron')
-contextBridge.exposeInMainWorld('versions', process.versions)
+const { contextBridge, ipcRenderer } = require('electron')
+
+contextBridge.exposeInMainWorld('api', {
+  versions: process.versions,
+  quit: () => ipcRenderer.send('quit-app')
+})


### PR DESCRIPTION
## Summary
- display the game in fullscreen mode
- create a basic home screen with 3 centered buttons
- add simple styling for layout
- confirm exit with modal and handle app quit
- add options modal for language and volume

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686f061d908c832abef157d2625e7955