### PR TITLE
Enable debug shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,7 @@ npm run build
 npm start
 ```
 
+Durante a execução pressione **Ctrl+Shift+D** para abrir o console de
+desenvolvedor a qualquer momento.
+
 Os assets utilizados pelo React ficam em `Assets/`.

--- a/main.js
+++ b/main.js
@@ -1,8 +1,10 @@
-const { app, BrowserWindow, ipcMain } = require('electron')
+const { app, BrowserWindow, ipcMain, globalShortcut } = require('electron')
 const path = require('path')
 
+let mainWindow
+
 function createWindow() {
-  const win = new BrowserWindow({
+  mainWindow = new BrowserWindow({
     fullscreen: true,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js')
@@ -10,14 +12,20 @@ function createWindow() {
   })
 
   if (app.isPackaged) {
-    win.loadFile(path.join(__dirname, 'frontend', 'dist', 'index.html'))
+    mainWindow.loadFile(path.join(__dirname, 'frontend', 'dist', 'index.html'))
   } else {
-    win.loadURL('http://localhost:5173')
+    mainWindow.loadURL('http://localhost:5173')
   }
 }
 
 app.whenReady().then(() => {
   createWindow()
+
+  globalShortcut.register('CommandOrControl+Shift+D', () => {
+    if (mainWindow) {
+      mainWindow.webContents.openDevTools({ mode: 'detach' })
+    }
+  })
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
@@ -30,4 +38,8 @@ ipcMain.on('quit-app', () => {
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit()
+})
+
+app.on('will-quit', () => {
+  globalShortcut.unregisterAll()
 })


### PR DESCRIPTION
## Summary
- open devtools with `Ctrl+Shift+D`
- document new debug shortcut

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686f09694598832a80497adf3a1d7f0f