### PR TITLE
Fix build output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Este projeto combina Electron e React para criar uma nova interface do jogo.
 ```bash
 npm run build
 ```
+O bundle sera gerado em `frontend/dist`.
 
 3. Inicie a aplicação com:
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build --outDir ../dist",
+    "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },


### PR DESCRIPTION
## Summary
- build React frontend to `frontend/dist`
- document build output location

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint config missing)*
- `npm run build --prefix frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0e82cbb8832aad9b8dfe36dea122