### PR TITLE
Fix blank screen by loading built HTML

### DIFF
--- a/main.js
+++ b/main.js
@@ -11,11 +11,7 @@ function createWindow() {
     }
   })
 
-  if (app.isPackaged) {
-    mainWindow.loadFile(path.join(__dirname, 'frontend', 'dist', 'index.html'))
-  } else {
-    mainWindow.loadURL('http://localhost:5173')
-  }
+  mainWindow.loadFile(path.join(__dirname, 'frontend', 'dist', 'index.html'))
 }
 
 app.whenReady().then(() => {


### PR DESCRIPTION
## Summary
- load `frontend/dist/index.html` by default instead of a dev server

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f1236b4e8832a8c4e478b7756af26