### PR TITLE
Add compatibility section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,17 @@ Durante a execução pressione **Ctrl+Shift+D** para abrir o console de
 desenvolvedor a qualquer momento.
 
 Os assets utilizados pelo React ficam em `Assets/`.
+
+## Compatibilidade
+
+* **Electron**: a aplicação usa Electron na versão indicada em
+  `package.json` (`^28.1.3`). Utilize uma versão compatível do Node.js
+  (18 ou superior) para garantir o correto funcionamento.
+* **React**: o frontend foi desenvolvido com React `^19.1.0`. Certifique-se
+  de que a versão do Node instalada atende aos requisitos dessa versão do
+  React.
+* **JavaScript/Node.js**: recomenda-se utilizar Node.js 18 ou superior para
+  compilar e executar o projeto sem problemas.
+
+Ao iniciar o aplicativo, a tela principal exibe três botões: **Iniciar**,
+**Opções** e **Sair**.


### PR DESCRIPTION
## Summary
- document Electron/Node/React compatibility
- note the Start/Options/Exit buttons in the home screen

## Testing
- `npm start` *(fails: electron not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f17417188832a87484aabd11c72aa