### PR TITLE
Add Electron integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ignora dependências e builds
 node_modules/
 dist/
+frontend/dist/
 build/
 
 # Ignora arquivos de log e cache do sistema

--- a/README.md
+++ b/README.md
@@ -19,5 +19,14 @@ Boilerplate usando **React**, **Vite** e **Tailwind CSS**.
    npm run build
    ```
 
+## Rodar como aplicativo desktop
+
+1. Gere a build de produção com `npm run build`.
+2. Em seguida, execute:
+   ```bash
+   npm run electron
+   ```
+   Isso abre o app em uma janela do Electron.
+
 Os assets utilizados pelo React ficam em `Assets/`.
 

--- a/main.js
+++ b/main.js
@@ -1,0 +1,29 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+const isDev = !app.isPackaged;
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      contextIsolation: true
+    }
+  });
+
+  if (isDev) {
+    win.loadURL('http://localhost:5173');
+  } else {
+    const indexPath = path.join(__dirname, 'frontend', 'dist', 'index.html');
+    win.loadFile(indexPath);
+  }
+}
+
+app.whenReady().then(createWindow);
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "scripts": {
     "start": "npm run dev --prefix frontend",
     "build": "npm run build --prefix frontend",
-    "preview": "npm run preview --prefix frontend"
+    "preview": "npm run preview --prefix frontend",
+    "electron": "electron ."
+  },
+  "devDependencies": {
+    "electron": "^29.3.0"
   }
 }


### PR DESCRIPTION
## Summary
- ignore the build folder for the frontend
- install Electron as a dev dependency and add a script to run it
- document how to open the app in Electron
- create `main.js` to bootstrap Electron

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find a config)*
- `npm run build --prefix frontend` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fddb6925c832abf812bf8c872a0b1