### PR TITLE
Improve start script to launch Electron automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Boilerplate usando **React**, **Vite** e **Tailwind CSS**.
    npm install
    npm install --prefix frontend
    ```
-3. Inicie o servidor de desenvolvimento:
+3. Inicie o servidor de desenvolvimento (abrirá o Electron automaticamente):
    ```bash
    npm start
    ```

--- a/package.json
+++ b/package.json
@@ -3,12 +3,13 @@
   "version": "1.0.0",
   "main": "main.js",
   "scripts": {
-    "start": "npm run dev --prefix frontend",
+    "start": "concurrently \"npm run dev --prefix frontend\" \"npm run electron\"",
     "build": "npm run build --prefix frontend",
     "preview": "npm run preview --prefix frontend",
     "electron": "electron ."
   },
   "devDependencies": {
-    "electron": "^29.3.0"
+    "electron": "^29.3.0",
+    "concurrently": "^8.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- run the dev server and Electron simultaneously with `npm start`
- mention the change in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ff54e5b80832a86bc897c0390d5f4