### PR TITLE
Adjust modal layout and cursor behavior

### DIFF
--- a/frontend/src/components/HomeScreen.jsx
+++ b/frontend/src/components/HomeScreen.jsx
@@ -88,39 +88,7 @@ export default function HomeScreen() {
       {showOptions && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
           <div className="bg-gray-800 p-4 rounded text-center">
-            <div className="space-x-4 mb-4">
-              <label className="cursor-pointer">
-                <input
-                  type="radio"
-                  value="pt"
-                  checked={language === 'pt'}
-                  onChange={() => setLanguage('pt')}
-                />
-                <span className="ml-1" role="img" aria-label="Brazil flag">🇧🇷</span> Português
-              </label>
-              <label className="cursor-pointer">
-                <input
-                  type="radio"
-                  value="en"
-                  checked={language === 'en'}
-                  onChange={() => setLanguage('en')}
-                />
-                <span className="ml-1" role="img" aria-label="USA flag">🇺🇸</span> Inglês
-              </label>
-            </div>
-            <div className="flex items-center mb-4">
-              <span role="img" aria-label="muted" className="cursor-pointer" onClick={() => setVolume(0)}>🔇</span>
-              <input
-                className="mx-2"
-                type="range"
-                min="0"
-                max="100"
-                value={volume}
-                onChange={(e) => setVolume(Number(e.target.value))}
-              />
-              <span role="img" aria-label="sound" className="cursor-pointer" onClick={() => setVolume(100)}>🔊</span>
-            </div>
-            <label className="cursor-pointer flex items-center mb-4">
+            <label className="flex justify-center items-center mb-4">
               <input
                 type="checkbox"
                 className="mr-2"
@@ -129,6 +97,38 @@ export default function HomeScreen() {
               />
               Tela cheia
             </label>
+            <div className="space-x-4 mb-4">
+              <label>
+                <input
+                  type="radio"
+                  value="pt"
+                  checked={language === 'pt'}
+                  onChange={() => setLanguage('pt')}
+                />
+                <span className="ml-1" role="img" aria-label="Brazil flag">🇧🇷</span> PT-BR
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  value="en"
+                  checked={language === 'en'}
+                  onChange={() => setLanguage('en')}
+                />
+                <span className="ml-1" role="img" aria-label="USA flag">🇺🇸</span> US
+              </label>
+            </div>
+            <div className="flex items-center mb-4">
+              <span role="img" aria-label="muted" onClick={() => setVolume(0)}>🔇</span>
+              <input
+                className="mx-2"
+                type="range"
+                min="0"
+                max="100"
+                value={volume}
+                onChange={(e) => setVolume(Number(e.target.value))}
+              />
+              <span role="img" aria-label="sound" onClick={() => setVolume(100)}>🔊</span>
+            </div>
             <button
               className="button"
               onClick={() => setShowOptions(false)}

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -37,7 +37,7 @@ img {
     font-size: 14px;
     color: #ffffff;
     text-shadow: 1px 1px 2px black, -1px -1px 2px black, 1px -1px 2px black, -1px 1px 2px black;
-    cursor: pointer;
+    cursor: default;
     transition: background-color 0.2s ease;
     width: 120px;
     text-align: center;


### PR DESCRIPTION
## Summary
- keep pointer disabled for buttons to maintain arrow cursor
- center fullscreen option at top of options modal
- show language choices as PT-BR and US
- remove pointer style from interactive icons

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find configuration)*
- `npm run build --prefix frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68703273d33c832aa380704858b2ac3f