### PR TITLE
Add custom title bar

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,8 +1,12 @@
 import React from 'react'
 import HomeScreen from './components/HomeScreen'
+import TitleBar from './components/TitleBar'
 
 export default function App() {
   return (
-    <HomeScreen />
+    <>
+      <TitleBar />
+      <HomeScreen />
+    </>
   )
 }

--- a/frontend/src/components/TitleBar.jsx
+++ b/frontend/src/components/TitleBar.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export default function TitleBar() {
+  const handleMinimize = () => window.api?.minimize()
+  const handleMaximize = () => window.api?.toggleMaximize()
+  const handleClose = () => window.api?.close()
+
+  return (
+    <div id="title-bar">
+      <div id="title-bar-content">Kadir11</div>
+      <div id="title-bar-buttons">
+        <div className="title-btn minimize-btn" onClick={handleMinimize}>–</div>
+        <div className="title-btn maximize-btn" onClick={handleMaximize}>▢</div>
+        <div className="title-btn close-btn" onClick={handleClose}>×</div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -90,3 +90,60 @@ img {
 .scroll-container::-webkit-scrollbar-track {
     background-color: #101218;
 }
+
+/* Title bar styles */
+#title-bar {
+    position: relative;
+    width: 100%;
+    height: 30px !important;
+    min-height: 30px;
+    line-height: 30px;
+    background: #3a4450;
+    -webkit-app-region: drag;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 5px;
+}
+
+#title-bar-content {
+    display: flex;
+    align-items: center;
+    flex-grow: 1;
+}
+
+#title-bar-buttons {
+    display: flex;
+    gap: 5px;
+    -webkit-app-region: no-drag;
+}
+
+.title-btn {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    cursor: pointer;
+    -webkit-app-region: no-drag;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: cursive;
+    font-size: 12px;
+    font-weight: bold;
+    text-shadow: none;
+}
+
+.close-btn {
+    background: #ff4444;
+    color: #813a3a;
+}
+
+.minimize-btn {
+    background: #f4d11f;
+    color: #7c6a2c;
+}
+
+.maximize-btn {
+    background: #44ff88;
+    color: #317a59;
+}

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, globalShortcut } = require('electron');
+const { app, BrowserWindow, globalShortcut, ipcMain } = require('electron');
 const path = require('path');
 
 const isDev = !app.isPackaged;
@@ -12,10 +12,14 @@ function createWindow() {
     minWidth: 800,
     minHeight: 600,
     backgroundColor: '#000000',
+    frame: false,
     webPreferences: {
-      contextIsolation: true
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preload.js')
     }
   });
+
+  win.setMenuBarVisibility(false);
 
   if (isDev) {
     win.loadURL('http://localhost:5173');
@@ -30,6 +34,22 @@ app.whenReady().then(() => {
   globalShortcut.register('CommandOrControl+Shift+D', () => {
     if (win) {
       win.webContents.openDevTools();
+    }
+  });
+
+  ipcMain.on('window-close', () => {
+    win.close();
+  });
+
+  ipcMain.on('window-minimize', () => {
+    win.minimize();
+  });
+
+  ipcMain.on('window-toggle-maximize', () => {
+    if (win.isMaximized()) {
+      win.unmaximize();
+    } else {
+      win.maximize();
     }
   });
 });

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,7 @@
+const { contextBridge, ipcRenderer } = require('electron')
+
+contextBridge.exposeInMainWorld('api', {
+  close: () => ipcRenderer.send('window-close'),
+  minimize: () => ipcRenderer.send('window-minimize'),
+  toggleMaximize: () => ipcRenderer.send('window-toggle-maximize'),
+})


### PR DESCRIPTION
## Summary
- remove OS frame from Electron window
- expose window controls in a new preload script
- implement IPC handlers for minimize/maximize/close
- create TitleBar React component
- integrate TitleBar in the app
- style title bar in global styles

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68704318f0fc832aa0219519f866fbb3