### PR TITLE
Implement fullscreen TitleBar toggle

### DIFF
--- a/frontend/src/components/TitleBar.jsx
+++ b/frontend/src/components/TitleBar.jsx
@@ -1,6 +1,16 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 export default function TitleBar() {
+  const [isFullscreen, setIsFullscreen] = useState(false)
+
+  useEffect(() => {
+    const handleChange = () => setIsFullscreen(!!document.fullscreenElement)
+    document.addEventListener('fullscreenchange', handleChange)
+    return () => document.removeEventListener('fullscreenchange', handleChange)
+  }, [])
+
+  if (isFullscreen) return null
+
   const handleMinimize = () => window.api?.minimize()
   const handleMaximize = () => window.api?.toggleMaximize()
   const handleClose = () => window.api?.close()

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,8 +4,16 @@
 
 html, body, #root {
   height: 100%;
+  overflow: hidden;
 }
 
 body {
   @apply bg-gray-900 text-white;
+  /* Hide scrollbars */
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
+body::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera */
 }


### PR DESCRIPTION
## Summary
- hide scrollbars globally
- hide TitleBar when in fullscreen mode

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find a configuration file)*
- `npm run build --prefix frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687044a50d28832a88389c42ad8ff9b3