### PR TITLE
Implement quit IPC for Electron

### DIFF
--- a/main.js
+++ b/main.js
@@ -52,6 +52,10 @@ app.whenReady().then(() => {
       win.maximize();
     }
   });
+
+  ipcMain.on('app-quit', () => {
+    app.quit();
+  });
 });
 
 app.on('will-quit', () => {

--- a/preload.js
+++ b/preload.js
@@ -4,4 +4,5 @@ contextBridge.exposeInMainWorld('api', {
   close: () => ipcRenderer.send('window-close'),
   minimize: () => ipcRenderer.send('window-minimize'),
   toggleMaximize: () => ipcRenderer.send('window-toggle-maximize'),
+  quit: () => ipcRenderer.send('app-quit'),
 })


### PR DESCRIPTION
## Summary
- expose `quit` from preload to send an `app-quit` message
- handle `app-quit` in Electron main process to call `app.quit()`

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68704c7220d8832a82441ee69da0a6ca