### PR TITLE
Adjust intro timing

### DIFF
--- a/frontend/src/components/HomeScreen.jsx
+++ b/frontend/src/components/HomeScreen.jsx
@@ -30,7 +30,7 @@ export default function HomeScreen() {
   }, [])
 
   useEffect(() => {
-    const logoTimer = setTimeout(() => setShowLogo2(true), 3000)
+    const logoTimer = setTimeout(() => setShowLogo2(true), 4000)
     return () => clearTimeout(logoTimer)
   }, [])
 
@@ -50,7 +50,7 @@ export default function HomeScreen() {
       if (audioRef.current) {
         audioRef.current.play().catch(() => {})
       }
-    }, 3000)
+    }, 2000)
     return () => clearTimeout(timer)
   }, [])
 
@@ -74,7 +74,7 @@ export default function HomeScreen() {
         <img
           src={logo1}
           alt="Kadir11"
-          className={`absolute w-[700px] transition-opacity duration-1000 ${showLogo1 ? (showLogo2 ? 'opacity-0' : 'opacity-90') : 'opacity-0'}`}
+          className={`absolute w-[700px] transition-opacity duration-[4000ms] ${showLogo1 ? (showLogo2 ? 'opacity-0' : 'opacity-90') : 'opacity-0'}`}
           style={{ mixBlendMode: 'screen', top: '130px' }}
         />
         <img


### PR DESCRIPTION
## Summary
- delay start of second logo
- start background music after 2s
- slow fade-in of first logo

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint config missing)*
- `npm run build --prefix frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68704e1c9be8832ab1ea78e09e6718e5