### PR TITLE
Update HomeScreen timing

### DIFF
--- a/frontend/src/components/HomeScreen.jsx
+++ b/frontend/src/components/HomeScreen.jsx
@@ -50,7 +50,7 @@ export default function HomeScreen() {
       if (audioRef.current) {
         audioRef.current.play().catch(() => {})
       }
-    }, 2000)
+    }, 0)
     return () => clearTimeout(timer)
   }, [])
 
@@ -74,7 +74,7 @@ export default function HomeScreen() {
         <img
           src={logo1}
           alt="Kadir11"
-          className={`absolute w-[700px] transition-opacity duration-[4000ms] ${showLogo1 ? (showLogo2 ? 'opacity-0' : 'opacity-90') : 'opacity-0'}`}
+          className={`absolute w-[700px] transition-opacity duration-[2000ms] ${showLogo1 ? (showLogo2 ? 'opacity-0' : 'opacity-90') : 'opacity-0'}`}
           style={{ mixBlendMode: 'screen', top: '130px' }}
         />
         <img


### PR DESCRIPTION
## Summary
- play background music right away
- reduce initial logo fade-in from 4s to 2s

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_687050ae4e7c832aa4c9e74e20b99c44