### PR TITLE
Implement options persistence

### DIFF
--- a/frontend/src/components/HomeScreen.jsx
+++ b/frontend/src/components/HomeScreen.jsx
@@ -24,6 +24,29 @@ export default function HomeScreen() {
     setIsFullscreen(enable)
   }
 
+  // Load saved preferences on first render
+  useEffect(() => {
+    const storedVolume = localStorage.getItem('volume')
+    if (storedVolume !== null) {
+      setVolume(Number(storedVolume))
+    }
+
+    const storedFullscreen = localStorage.getItem('isFullscreen') === 'true'
+    if (storedFullscreen) {
+      toggleFullscreen(true)
+    }
+  }, [])
+
+  // Persist volume changes
+  useEffect(() => {
+    localStorage.setItem('volume', String(volume))
+  }, [volume])
+
+  // Persist fullscreen changes
+  useEffect(() => {
+    localStorage.setItem('isFullscreen', String(isFullscreen))
+  }, [isFullscreen])
+
   useEffect(() => {
     const timer = setTimeout(() => setShowLogo1(true), 0)
     return () => clearTimeout(timer)


### PR DESCRIPTION
## Summary
- store user volume and fullscreen preferences in localStorage
- load saved preferences on app start

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_687055774a50832a8fb45b3132e658b0