### PR TITLE
Persist user options and add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -30,3 +30,14 @@ Boilerplate usando **React**, **Vite** e **Tailwind CSS**.
 
 Os assets utilizados pelo React ficam em `Assets/`.
 
+### Nota sobre tela cheia
+
+Alguns navegadores bloqueiam a entrada automática em modo tela cheia caso não
+haja interação do usuário. Se você habilitar a opção "Tela cheia" nas
+configurações e o jogo não abrir expandido, ative o modo manualmente pelo
+menu de opções.
+
+## Licença
+
+Este projeto está licenciado sob os termos da [MIT License](LICENSE).
+

--- a/frontend/src/components/HomeScreen.jsx
+++ b/frontend/src/components/HomeScreen.jsx
@@ -17,11 +17,18 @@ export default function HomeScreen() {
 
   const toggleFullscreen = (enable) => {
     if (enable) {
-      document.documentElement.requestFullscreen().catch(() => {})
+      document.documentElement
+        .requestFullscreen()
+        .then(() => setIsFullscreen(true))
+        .catch(() => setIsFullscreen(false))
     } else if (document.fullscreenElement) {
-      document.exitFullscreen()
+      document
+        .exitFullscreen()
+        .then(() => setIsFullscreen(false))
+        .catch(() => {})
+    } else {
+      setIsFullscreen(false)
     }
-    setIsFullscreen(enable)
   }
 
   // Load saved preferences on first render
@@ -29,6 +36,11 @@ export default function HomeScreen() {
     const storedVolume = localStorage.getItem('volume')
     if (storedVolume !== null) {
       setVolume(Number(storedVolume))
+    }
+
+    const storedLang = localStorage.getItem('language')
+    if (storedLang) {
+      setLanguage(storedLang)
     }
 
     const storedFullscreen = localStorage.getItem('isFullscreen') === 'true'
@@ -42,10 +54,24 @@ export default function HomeScreen() {
     localStorage.setItem('volume', String(volume))
   }, [volume])
 
+  // Persist language changes
+  useEffect(() => {
+    localStorage.setItem('language', language)
+  }, [language])
+
   // Persist fullscreen changes
   useEffect(() => {
     localStorage.setItem('isFullscreen', String(isFullscreen))
   }, [isFullscreen])
+
+  // Keep state in sync with actual fullscreen status
+  useEffect(() => {
+    const handleChange = () => {
+      setIsFullscreen(!!document.fullscreenElement)
+    }
+    document.addEventListener('fullscreenchange', handleChange)
+    return () => document.removeEventListener('fullscreenchange', handleChange)
+  }, [])
 
   useEffect(() => {
     const timer = setTimeout(() => setShowLogo1(true), 0)


### PR DESCRIPTION
## Summary
- ensure fullscreen state only updates when browser APIs succeed
- keep fullscreen checkbox in sync with the real state
- persist selected language in localStorage
- document fullscreen limitations
- add MIT license

## Testing
- `npm start` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870591b5af8832aa201bcb576f15a5b