### PR TITLE
Hide Windows cursor at load

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kadir11</title>
   </head>
-  <body>
+  <body style="cursor: none;">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,8 +4,6 @@ import App from './App'
 import './index.css'
 import './global.css'
 
-document.body.classList.add('hide-default-cursor')
-
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
## Summary
- hide system cursor in `index.html` so only custom cursor shows
- remove JS hook for hiding body cursor

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6870630f73e4832aa91c874ac5556159