### PR TITLE
Persist settings via electron-store

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ Boilerplate usando **React**, **Vite** e **Tailwind CSS**.
    ```bash
    npm run electron
    ```
-   Isso abre o app em uma janela do Electron.
+Isso abre o app em uma janela do Electron.
 
 Os assets utilizados pelo React ficam em `Assets/`.
+
+As preferências do usuário (volume, idioma e modo de tela cheia) são
+armazenadas com [electron-store](https://github.com/sindresorhus/electron-store)
+quando o jogo roda como aplicativo desktop.
 
 ### Nota sobre tela cheia
 

--- a/frontend/src/components/HomeScreen.jsx
+++ b/frontend/src/components/HomeScreen.jsx
@@ -15,6 +15,21 @@ export default function HomeScreen() {
   const [isFullscreen, setIsFullscreen] = useState(false)
   const audioRef = useRef(null)
 
+  const getPref = (key) => {
+    if (window.api?.getPreference) {
+      return window.api.getPreference(key)
+    }
+    return localStorage.getItem(key)
+  }
+
+  const setPref = (key, value) => {
+    if (window.api?.setPreference) {
+      window.api.setPreference(key, value)
+    } else {
+      localStorage.setItem(key, String(value))
+    }
+  }
+
   const toggleFullscreen = (enable) => {
     if (enable) {
       document.documentElement
@@ -33,35 +48,35 @@ export default function HomeScreen() {
 
   // Load saved preferences on first render
   useEffect(() => {
-    const storedVolume = localStorage.getItem('volume')
-    if (storedVolume !== null) {
+    const storedVolume = getPref('volume')
+    if (storedVolume !== null && storedVolume !== undefined) {
       setVolume(Number(storedVolume))
     }
 
-    const storedLang = localStorage.getItem('language')
+    const storedLang = getPref('language')
     if (storedLang) {
       setLanguage(storedLang)
     }
 
-    const storedFullscreen = localStorage.getItem('isFullscreen') === 'true'
-    if (storedFullscreen) {
+    const storedFullscreen = getPref('isFullscreen')
+    if (storedFullscreen === true || storedFullscreen === 'true') {
       toggleFullscreen(true)
     }
   }, [])
 
   // Persist volume changes
   useEffect(() => {
-    localStorage.setItem('volume', String(volume))
+    setPref('volume', volume)
   }, [volume])
 
   // Persist language changes
   useEffect(() => {
-    localStorage.setItem('language', language)
+    setPref('language', language)
   }, [language])
 
   // Persist fullscreen changes
   useEffect(() => {
-    localStorage.setItem('isFullscreen', String(isFullscreen))
+    setPref('isFullscreen', isFullscreen)
   }, [isFullscreen])
 
   // Keep state in sync with actual fullscreen status

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   },
   "devDependencies": {
     "electron": "^29.4.6"
+  },
+  "dependencies": {
+    "electron-store": "^8.1.0"
   }
 }

--- a/preload.js
+++ b/preload.js
@@ -1,8 +1,13 @@
 const { contextBridge, ipcRenderer } = require('electron')
+const Store = require('electron-store')
+
+const store = new Store()
 
 contextBridge.exposeInMainWorld('api', {
   close: () => ipcRenderer.send('window-close'),
   minimize: () => ipcRenderer.send('window-minimize'),
   toggleMaximize: () => ipcRenderer.send('window-toggle-maximize'),
   quit: () => ipcRenderer.send('app-quit'),
+  getPreference: (key) => store.get(key),
+  setPreference: (key, value) => store.set(key, value),
 })


### PR DESCRIPTION
## Summary
- add `electron-store` dependency
- expose preference helpers in `preload.js`
- use new helpers in `HomeScreen` to load and save settings
- mention electron-store in the README

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6871061122ac832abeaf7f2d32184800