### PR TITLE
Add questionnaire step with random stat questions

### DIFF
--- a/frontend/src/components/IntroModal.jsx
+++ b/frontend/src/components/IntroModal.jsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react'
+import Questionnaire from './Questionnaire'
 
 export default function IntroModal({ onClose }) {
   const [name, setName] = useState('')
   const [confirmed, setConfirmed] = useState(false)
+  const [showQuestions, setShowQuestions] = useState(false)
 
   const handleChange = (e) => {
     const value = e.target.value.slice(0, 15)
@@ -15,31 +17,39 @@ export default function IntroModal({ onClose }) {
     }
   }
 
+  const handleProceed = () => {
+    setShowQuestions(true)
+  }
+
+  const handleComplete = () => {
+    onClose(name)
+  }
+
   return (
     <div className="text-center space-y-4">
       <div
         className={`transition-opacity duration-500 ${
-          confirmed ? 'opacity-0 pointer-events-none' : 'opacity-100'
+          !confirmed && !showQuestions ? 'opacity-100' : 'opacity-0 pointer-events-none'
         }`}
       >
-        <p>Boas vindas, viajante...</p>
-        <input
-          type="text"
-          value={name}
-          onChange={handleChange}
-          maxLength={15}
-          className="bg-gray-800 border border-gray-700 p-2 text-center"
-        />
-        <div>
-          <button className="button" onClick={handleConfirm}>
-            Prosseguir
-          </button>
+          <p>Boas vindas, viajante...</p>
+          <input
+            type="text"
+            value={name}
+            onChange={handleChange}
+            maxLength={15}
+            className="bg-gray-800 border border-gray-700 p-2 text-center"
+          />
+          <div>
+            <button className="button" onClick={handleConfirm}>
+              Prosseguir
+            </button>
+          </div>
         </div>
-      </div>
 
       <div
         className={`transition-opacity duration-500 ${
-          confirmed ? 'opacity-100' : 'opacity-0 pointer-events-none'
+          confirmed && !showQuestions ? 'opacity-100' : 'opacity-0 pointer-events-none'
         }`}
       >
         <p>
@@ -48,11 +58,13 @@ export default function IntroModal({ onClose }) {
           lendas ganham vida...
         </p>
         <div>
-          <button className="button" onClick={() => onClose(name)}>
+          <button className="button" onClick={handleProceed}>
             Próximo
           </button>
         </div>
       </div>
+
+      {showQuestions && <Questionnaire onComplete={handleComplete} />}
     </div>
   )
 }

--- a/frontend/src/components/Questionnaire.jsx
+++ b/frontend/src/components/Questionnaire.jsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react'
+import QUESTIONS from './questions'
+
+export default function Questionnaire({ onComplete }) {
+  const [qList, setQList] = useState([])
+  const [index, setIndex] = useState(0)
+  const [stats, setStats] = useState({ attack: 0, defense: 0, magic: 0, velocity: 0 })
+  const [transition, setTransition] = useState(false)
+
+  useEffect(() => {
+    const shuffled = [...QUESTIONS].sort(() => Math.random() - 0.5)
+    setQList(shuffled.slice(0, 5))
+  }, [])
+
+  if (qList.length === 0) return null
+
+  const current = qList[index]
+
+  const handleSelect = (key) => {
+    const option = current.options[key]
+    const newStats = {
+      attack: stats.attack + (option.attack || 0),
+      defense: stats.defense + (option.defense || 0),
+      magic: stats.magic + (option.magic || 0),
+      velocity: stats.velocity + (option.velocity || 0),
+    }
+    setStats(newStats)
+    setTransition(true)
+    setTimeout(() => {
+      if (index + 1 === qList.length) {
+        onComplete(newStats)
+      } else {
+        setIndex((i) => i + 1)
+        setTransition(false)
+      }
+    }, 300)
+  }
+
+  return (
+    <div className="text-center">
+      <div
+        className={`transition-all duration-300 ${
+          transition ? '-translate-x-4 opacity-0' : 'translate-x-0 opacity-100'
+        }`}
+      >
+        <p className="mb-4">{current.text}</p>
+        <div className="flex justify-center space-x-4">
+          {['A', 'B', 'C'].map((key) => (
+            <button className="button" key={key} onClick={() => handleSelect(key)}>
+              {key}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/questions.js
+++ b/frontend/src/components/questions.js
@@ -1,0 +1,164 @@
+const QUESTIONS = [
+  {
+    text: 'Ao cruzar uma floresta densa, você decide...',
+    options: {
+      A: { attack: 1 },
+      B: { defense: 1 },
+      C: { magic: 1 },
+    },
+  },
+  {
+    text: 'Um comerciante oferece botas muito leves.',
+    options: {
+      A: { velocity: 1 },
+      B: { attack: 1 },
+      C: { defense: 1 },
+    },
+  },
+  {
+    text: 'Você encontra um tomo arcano.',
+    options: {
+      A: { magic: 1 },
+      B: { attack: 1 },
+      C: { defense: 1 },
+    },
+  },
+  {
+    text: 'Um treinador lhe oferece uma sessão rápida.',
+    options: {
+      A: { attack: 1 },
+      B: { defense: 1 },
+      C: { velocity: 1 },
+    },
+  },
+  {
+    text: 'Durante a viagem, você sente energia mágica.',
+    options: {
+      A: { magic: 1 },
+      B: { attack: 1 },
+      C: { defense: 1 },
+    },
+  },
+  {
+    text: 'Uma ponte velha ameaça desabar.',
+    options: {
+      A: { velocity: 1 },
+      B: { defense: 1 },
+      C: { attack: 1 },
+    },
+  },
+  {
+    text: 'Você recebe convite para duelo.',
+    options: {
+      A: { attack: 1 },
+      B: { magic: 1 },
+      C: { defense: 1 },
+    },
+  },
+  {
+    text: 'Um sábio propõe ensinar feitiços.',
+    options: {
+      A: { magic: 1 },
+      B: { attack: 1 },
+      C: { defense: 1 },
+    },
+  },
+  {
+    text: 'Na taverna, um estranho pede ajuda.',
+    options: {
+      A: { defense: 1 },
+      B: { attack: 1 },
+      C: { velocity: 1 },
+    },
+  },
+  {
+    text: 'Você acha uma armadura brilhante.',
+    options: {
+      A: { defense: 1 },
+      B: { attack: 1 },
+      C: { magic: 1 },
+    },
+  },
+  {
+    text: 'Uma corrida é anunciada na cidade.',
+    options: {
+      A: { velocity: 1 },
+      B: { attack: 1 },
+      C: { defense: 1 },
+    },
+  },
+  {
+    text: 'Você avista ruínas antigas no horizonte.',
+    options: {
+      A: { magic: 1 },
+      B: { defense: 1 },
+      C: { attack: 1 },
+    },
+  },
+  {
+    text: 'Um mercenário quer treinar sua força.',
+    options: {
+      A: { attack: 1 },
+      B: { velocity: 1 },
+      C: { defense: 1 },
+    },
+  },
+  {
+    text: 'Você encontra poção de velocidade.',
+    options: {
+      A: { velocity: 1 },
+      B: { attack: 1 },
+      C: { magic: 1 },
+    },
+  },
+  {
+    text: 'Um espírito antigo tenta lhe possuir.',
+    options: {
+      A: { magic: 1 },
+      B: { defense: 1 },
+      C: { attack: 1 },
+    },
+  },
+  {
+    text: 'Você tropeça em uma emboscada.',
+    options: {
+      A: { defense: 1 },
+      B: { attack: 1 },
+      C: { velocity: 1 },
+    },
+  },
+  {
+    text: 'Um vilarejo pede proteção contra monstros.',
+    options: {
+      A: { attack: 1 },
+      B: { defense: 1 },
+      C: { magic: 1 },
+    },
+  },
+  {
+    text: 'Você descobre um atalho perigoso.',
+    options: {
+      A: { velocity: 1 },
+      B: { attack: 1 },
+      C: { defense: 1 },
+    },
+  },
+  {
+    text: 'Um ferreiro oferece aprimorar suas armas.',
+    options: {
+      A: { attack: 1 },
+      B: { defense: 1 },
+      C: { magic: 1 },
+    },
+  },
+  {
+    text: 'Durante uma tempestade, você busca abrigo.',
+    options: {
+      A: { defense: 1 },
+      B: { magic: 1 },
+      C: { velocity: 1 },
+    },
+  },
+]
+
+export default QUESTIONS


### PR DESCRIPTION
## Summary
- add 20 question objects with stat effects
- create `Questionnaire` component to ask five random questions
- integrate questionnaire flow into `IntroModal`

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68711c83a288832a97b48610ee125d17