### PR TITLE
Add ElementPicker component

### DIFF
--- a/frontend/src/components/ElementPicker.jsx
+++ b/frontend/src/components/ElementPicker.jsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react'
+import agua from '../../../Assets/Elements/agua.png'
+import fogo from '../../../Assets/Elements/fogo.png'
+import terra from '../../../Assets/Elements/terra.png'
+import ar from '../../../Assets/Elements/ar.png'
+import puro from '../../../Assets/Elements/puro.png'
+
+export default function ElementPicker({ stats, onSelect }) {
+  const elements = [
+    { key: 'fogo', label: 'Fogo', img: fogo },
+    { key: 'agua', label: 'Água', img: agua },
+    { key: 'terra', label: 'Terra', img: terra },
+    { key: 'ar', label: 'Ar', img: ar },
+    { key: 'puro', label: 'Puro', img: puro },
+  ]
+
+  const [hovered, setHovered] = useState(null)
+
+  const handleSelect = (key) => {
+    if (onSelect) {
+      onSelect({ ...stats, element: key })
+    }
+  }
+
+  return (
+    <div className="flex justify-center space-x-6">
+      {elements.map((el) => (
+        <div
+          key={el.key}
+          className="flex flex-col items-center"
+          onMouseEnter={() => setHovered(el.key)}
+          onMouseLeave={() => setHovered(null)}
+        >
+          <img
+            src={el.img}
+            alt={el.label}
+            className={`w-24 h-24 transition-transform duration-200 float-hover`}
+            onClick={() => handleSelect(el.key)}
+          />
+          {hovered === el.key && <span className="mt-1">{el.label}</span>}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/IntroModal.jsx
+++ b/frontend/src/components/IntroModal.jsx
@@ -1,10 +1,13 @@
 import React, { useState } from 'react'
 import Questionnaire from './Questionnaire'
+import ElementPicker from './ElementPicker'
 
 export default function IntroModal({ onClose }) {
   const [name, setName] = useState('')
   const [confirmed, setConfirmed] = useState(false)
   const [showQuestions, setShowQuestions] = useState(false)
+  const [stats, setStats] = useState(null)
+  const [showPicker, setShowPicker] = useState(false)
 
   const handleChange = (e) => {
     const value = e.target.value.slice(0, 15)
@@ -21,8 +24,13 @@ export default function IntroModal({ onClose }) {
     setShowQuestions(true)
   }
 
-  const handleComplete = () => {
-    onClose(name)
+  const handleComplete = (attrs) => {
+    setStats(attrs)
+    setShowPicker(true)
+  }
+
+  const handleElement = (finalStats) => {
+    onClose({ name, ...finalStats })
   }
 
   return (
@@ -64,7 +72,10 @@ export default function IntroModal({ onClose }) {
         </div>
       </div>
 
-      {showQuestions && <Questionnaire onComplete={handleComplete} />}
+      {showQuestions && !showPicker && (
+        <Questionnaire onComplete={handleComplete} />
+      )}
+      {showPicker && <ElementPicker stats={stats} onSelect={handleElement} />}
     </div>
   )
 }

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -152,3 +152,16 @@ img {
     background: #44ff88;
     color: #317a59;
 }
+
+@keyframes float {
+    0%, 100% {
+        transform: translateY(0);
+    }
+    50% {
+        transform: translateY(-6px);
+    }
+}
+
+.float-hover:hover {
+    animation: float 1.5s ease-in-out infinite;
+}


### PR DESCRIPTION
## Summary
- introduce `ElementPicker` for choosing an element
- animate on hover and show element name
- update `IntroModal` to display the picker after the questionnaire
- add float animation styles

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68711d9c8250832ab11673498129df84