### PR TITLE
Fix title bar buttons and center pet creation pages

### DIFF
--- a/frontend/src/components/CustomCursor.jsx
+++ b/frontend/src/components/CustomCursor.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import grabImg from '../../../Assets/Cursors/grab.png'
-import cursorImg from '../../../Assets/Cursors/cursor.png'
+import cursorImg from '../../../Assets/Cursors/pointer.png'
 
 export default function CustomCursor() {
   const [coords, setCoords] = useState({ x: 0, y: 0 })

--- a/frontend/src/components/ElementPage.jsx
+++ b/frontend/src/components/ElementPage.jsx
@@ -24,5 +24,9 @@ export default function ElementPage() {
 
   if (!name || !stats) return null
 
-  return <ElementPicker stats={stats} onSelect={handleSelect} />
+  return (
+    <div className="flex items-center justify-center h-full">
+      <ElementPicker stats={stats} onSelect={handleSelect} />
+    </div>
+  )
 }

--- a/frontend/src/components/IntroPage.jsx
+++ b/frontend/src/components/IntroPage.jsx
@@ -21,12 +21,13 @@ export default function IntroPage() {
   }
 
   return (
-    <div className="text-center space-y-4">
-      <div
-        className={`transition-opacity duration-500 ${
-          !confirmed ? 'opacity-100' : 'opacity-0 pointer-events-none'
-        }`}
-      >
+    <div className="flex items-center justify-center h-full">
+      <div className="text-center space-y-4">
+        <div
+          className={`transition-opacity duration-500 ${
+            !confirmed ? 'opacity-100' : 'opacity-0 pointer-events-none'
+          }`}
+        >
         <p>Boas vindas, viajante...</p>
         <input
           type="text"
@@ -42,11 +43,11 @@ export default function IntroPage() {
         </div>
       </div>
 
-      <div
-        className={`transition-opacity duration-500 ${
-          confirmed ? 'opacity-100' : 'opacity-0 pointer-events-none'
-        }`}
-      >
+        <div
+          className={`transition-opacity duration-500 ${
+            confirmed ? 'opacity-100' : 'opacity-0 pointer-events-none'
+          }`}
+        >
         <p>
           O destino o trouxe até{' '}
           <span className="text-yellow-400">Kadir</span>, um mundo onde as lendas ganham vida...

--- a/frontend/src/components/QuestionnairePage.jsx
+++ b/frontend/src/components/QuestionnairePage.jsx
@@ -17,5 +17,9 @@ export default function QuestionnairePage() {
 
   if (!name) return null
 
-  return <Questionnaire onComplete={handleComplete} />
+  return (
+    <div className="flex items-center justify-center h-full">
+      <Questionnaire onComplete={handleComplete} />
+    </div>
+  )
 }

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -129,6 +129,7 @@ img {
     border-radius: 50%;
     cursor: none;
     -webkit-app-region: no-drag;
+    pointer-events: auto;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## Summary
- ensure TitleBar buttons are clickable
- fix missing cursor image
- center pet creation screens vertically and horizontally

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_687125c03a84832ab40f774dca6940a4