### PR TITLE
Fix JSX in IntroPage

### DIFF
--- a/frontend/src/components/IntroPage.jsx
+++ b/frontend/src/components/IntroPage.jsx
@@ -58,6 +58,7 @@ export default function IntroPage() {
           </button>
         </div>
       </div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- fix unmatched closing tags in `IntroPage.jsx`

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find a configuration)*
- `npm run build --prefix frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687127d0d758832a9e5d3ef6d90c55c2