### PR TITLE
Fix questionnaire layout and hover interactions

### DIFF
--- a/frontend/src/components/ElementPicker.jsx
+++ b/frontend/src/components/ElementPicker.jsx
@@ -27,7 +27,7 @@ export default function ElementPicker({ stats, onSelect }) {
       {elements.map((el) => (
         <div
           key={el.key}
-          className="flex flex-col items-center"
+          className="relative flex flex-col items-center"
           onMouseEnter={() => setHovered(el.key)}
           onMouseLeave={() => setHovered(null)}
         >
@@ -37,7 +37,11 @@ export default function ElementPicker({ stats, onSelect }) {
             className={`w-24 h-24 transition-transform duration-200 float-hover`}
             onClick={() => handleSelect(el.key)}
           />
-          {hovered === el.key && <span className="mt-1">{el.label}</span>}
+          {hovered === el.key && (
+            <span className="absolute top-full mt-1 whitespace-nowrap">
+              {el.label}
+            </span>
+          )}
         </div>
       ))}
     </div>

--- a/frontend/src/components/Questionnaire.jsx
+++ b/frontend/src/components/Questionnaire.jsx
@@ -44,7 +44,7 @@ export default function Questionnaire({ onComplete }) {
         }`}
       >
         <p className="mb-4">{current.text}</p>
-        <div className="flex flex-col items-center space-y-2">
+        <div className="flex justify-center space-x-2">
           {['A', 'B', 'C'].map((key) => (
             <button
               className="button w-64"


### PR DESCRIPTION
## Summary
- show questionnaire options in a single row
- ensure element hover animation only affects the hovered item

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6871402dffc8832a832c1ac963b1910d