### PR TITLE
Fix electron dev detection for built app

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,9 @@
 const { app, BrowserWindow, globalShortcut, ipcMain } = require('electron');
 const path = require('path');
+const fs = require('fs');
 
-const isDev = !app.isPackaged;
+const distIndex = path.join(__dirname, 'frontend', 'dist', 'index.html');
+const isDev = !fs.existsSync(distIndex);
 
 let win;
 


### PR DESCRIPTION
## Summary
- detect production build by checking for `frontend/dist/index.html`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68715236c030832a9b1dd8f1e4056f3b