### PR TITLE
Add concurrent dev workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,26 @@ Boilerplate usando **React**, **Vite** e **Tailwind CSS**.
    ```bash
    npm start
    ```
-4. Para gerar a versão de produção:
+4. Para desenvolver o aplicativo desktop simultaneamente:
+   ```bash
+   npm run dev
+   ```
+5. Para gerar a versão de produção:
    ```bash
    npm run build
    ```
 
 ## Rodar como aplicativo desktop
 
-1. Gere a build de produção com `npm run build`.
-2. Em seguida, execute:
+1. Para testar em modo desenvolvimento, execute:
+   ```bash
+   npm run dev
+   ```
+   Isso abre o app em uma janela do Electron usando o servidor do Vite.
+2. Para gerar a versão de produção, rode `npm run build` e então:
    ```bash
    npm run electron
    ```
-Isso abre o app em uma janela do Electron.
 
 Os assets utilizados pelo React ficam em `Assets/`.
 

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "build": "npm run build --prefix frontend",
     "preview": "npm run preview --prefix frontend",
     "electron": "electron .",
+    "dev": "concurrently \"npm run dev --prefix frontend\" \"npm run electron\"",
     "postinstall": "npm install --prefix frontend"
   },
   "devDependencies": {
-    "electron": "^29.4.6"
+    "electron": "^29.4.6",
+    "concurrently": "^8.2.0"
   },
   "dependencies": {
     "electron-store": "^8.1.0"


### PR DESCRIPTION
## Summary
- add `concurrently` dev dependency
- add a `dev` script to start Electron with the Vite dev server
- document new workflow in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68715dfaa288832ab014c1485b8cc09e