### PR TITLE
Remove file-based dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "kadir11": "file:..",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.22.3"


### PR DESCRIPTION
## Summary
- clean up `frontend/package.json` by removing the unused `kadir11` file dependency

## Testing
- `npm install --prefix frontend` *(fails: unable to reach registry)*
- `npm run lint --prefix frontend` *(fails: missing eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_68715f11cf7c832aa9bb51c033d687c3