### PR TITLE
Remove leftover kadir11 dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,6 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "kadir11": "file:..",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -25,19 +24,6 @@
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.11",
         "vite": "^7.0.4"
-      }
-    },
-    "..": {
-      "name": "kadir11",
-      "version": "1.0.0",
-      "dependencies": {
-        "electron-store": "^8.2.0"
-      },
-      "devDependencies": {
-        "@tailwindcss/postcss": "^4.1.11",
-        "concurrently": "^9.2.0",
-        "electron": "^29.4.6",
-        "wait-on": "^8.0.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1362,10 +1348,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/kadir11": {
-      "resolved": "..",
-      "link": true
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "kadir11": "file:..",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },


### PR DESCRIPTION
## Summary
- remove local `kadir11` dependency from `frontend/package.json`
- drop `kadir11` references from `frontend/package-lock.json`

## Testing
- `npm install --prefix frontend` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6871679ff94c832abf25b2cc3e060431