### PR TITLE
Fix README entry reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Boilerplate usando **React**, **Vite** e **Tailwind CSS**.
    ```bash
    npm start
    ```
+   O Electron inicia a partir do arquivo `main.js` (e não `electron.js`).
 
 Os assets utilizados pelo React ficam em `Assets/`.
 

--- a/main.js
+++ b/main.js
@@ -1,3 +1,4 @@
+// Entry point for the Electron application
 const { app, BrowserWindow, globalShortcut, ipcMain } = require('electron');
 const path = require('path');
 const fs = require('fs');


### PR DESCRIPTION
## Summary
- mention that Electron starts from `main.js`
- mark `main.js` as Electron entry script

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_687168f01000832a825f2519dc9dc23c