### PR TITLE
Fix initial menu overflow and animate logo

### DIFF
--- a/frontend/src/components/HomeScreen.jsx
+++ b/frontend/src/components/HomeScreen.jsx
@@ -145,7 +145,7 @@ export default function HomeScreen() {
   }
 
   return (
-    <div className="relative flex flex-col items-center justify-center h-full">
+    <div className="relative flex flex-col items-center justify-center h-full w-full overflow-hidden">
       <img
         src={bgGif}
         alt="background"
@@ -156,13 +156,13 @@ export default function HomeScreen() {
         <img
           src={logo1}
           alt="Kadir11"
-          className={`absolute w-[700px] transition-opacity duration-[10000ms] ${showLogo1 ? (showLogo2 ? 'opacity-0' : 'opacity-90') : 'opacity-0'}`}
+          className={`absolute w-[700px] transition-opacity duration-[10000ms] ${showLogo1 ? (showLogo2 ? 'opacity-0' : 'opacity-90 logo-appear') : 'opacity-0'}`}
           style={{ mixBlendMode: 'screen', top: '130px' }}
         />
         <img
           src={logo2}
           alt="Kadir11"
-          className={`absolute w-[700px] transition-opacity duration-[3000ms] ${showLogo2 ? 'opacity-100' : 'opacity-0'}`}
+          className={`absolute w-[700px] transition-opacity duration-[3000ms] ${showLogo2 ? 'opacity-100 logo-appear' : 'opacity-0'}`}
           style={{ top: '130px' }}
         />
       </div>

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -13,6 +13,12 @@
     user-select: none;
 }
 
+html, body, #root {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+}
+
 input,
 textarea {
     user-select: text;
@@ -165,4 +171,19 @@ img {
 
 .float-hover:hover {
     animation: float 1.5s ease-in-out infinite;
+}
+
+@keyframes logoAppear {
+    from {
+        opacity: 0;
+        transform: scale(0.8);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+.logo-appear {
+    animation: logoAppear 1s ease-out forwards;
 }


### PR DESCRIPTION
## Summary
- avoid scrollbars by setting full-size root container
- add keyframes and class for logo appearance
- animate logos on HomeScreen
- ensure HomeScreen container matches viewport size

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint --prefix frontend` *(fails: cannot find @eslint/js)*


------
https://chatgpt.com/codex/tasks/task_e_687292e6c048832a8d5f02b98ac2d6d8