### PR TITLE
Update start screen styling and animations

### DIFF
--- a/src/components/StartScreen.css
+++ b/src/components/StartScreen.css
@@ -1,7 +1,8 @@
 .start-screen {
-  position: relative;
-  width: 1536px;
-  height: 1024px;
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
   overflow: hidden;
 }
 
@@ -18,19 +19,36 @@
 .start-logo {
   position: absolute;
   left: 50%;
-  transform: translate(-50%, 100%);
-  animation: logo-fade 1s forwards;
+  top: 50%;
+  width: 300px;
+  transform: translate(-50%, 50%);
+  animation: logo-fade-up 1s forwards;
   animation-delay: 0.5s;
 }
 
-@keyframes logo-fade {
+.logo-after {
+  animation: logo-fade-right 1s forwards;
+}
+
+@keyframes logo-fade-up {
   from {
     opacity: 0;
-    transform: translate(-50%, 100%);
+    transform: translate(-50%, 50%);
   }
   to {
     opacity: 1;
-    transform: translate(-50%, 0);
+    transform: translate(-50%, -50%);
+  }
+}
+
+@keyframes logo-fade-right {
+  from {
+    opacity: 0;
+    transform: translate(-150%, -50%);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%);
   }
 }
 

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -1,23 +1,34 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import './StartScreen.css'
 
 const StartScreen = () => {
   const audioRef = useRef<HTMLAudioElement>(null)
+  const [logoSrc, setLogoSrc] = useState('assets/logo/kadirbefore.png')
+  const [logoClass, setLogoClass] = useState('start-logo')
 
   useEffect(() => {
-    const timer = setTimeout(() => {
+    const audioTimer = setTimeout(() => {
       if (audioRef.current) {
         audioRef.current.loop = true
         audioRef.current.play().catch(() => {})
       }
     }, 2000)
-    return () => clearTimeout(timer)
+
+    const logoTimer = setTimeout(() => {
+      setLogoSrc('assets/logo/kadirafter.png')
+      setLogoClass('start-logo logo-after')
+    }, 3000)
+
+    return () => {
+      clearTimeout(audioTimer)
+      clearTimeout(logoTimer)
+    }
   }, [])
 
   return (
     <div className='start-screen'>
       <video className='start-video' src='assets/logo/videointro.mp4' autoPlay loop muted />
-      <img className='start-logo' src='assets/logo/kadirbefore.png' alt='logo' />
+      <img className={logoClass} src={logoSrc} alt='logo' />
       <div className='start-buttons'>
         <button>Iniciar</button>
         <button>Opções</button>


### PR DESCRIPTION
## Summary
- size start screen to viewport to avoid scrollbars
- animate logo appearance and change after delay
- use dynamic image state for switching logos

## Testing
- `npm test` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68729579ad8c832a8ab4c61d5b3ea374