### PR TITLE
Adjust start logo position and fade-in animation

### DIFF
--- a/frontend/src/components/HomeScreen.jsx
+++ b/frontend/src/components/HomeScreen.jsx
@@ -157,13 +157,13 @@ export default function HomeScreen() {
           src={logo1}
           alt="Kadir11"
           className={`absolute w-[700px] transition-opacity duration-[10000ms] ${showLogo1 ? (showLogo2 ? 'opacity-0' : 'opacity-90 logo-appear') : 'opacity-0'}`}
-          style={{ mixBlendMode: 'screen', top: '130px' }}
+          style={{ mixBlendMode: 'screen', top: '25%' }}
         />
         <img
           src={logo2}
           alt="Kadir11"
-          className={`absolute w-[700px] transition-opacity duration-[3000ms] ${showLogo2 ? 'opacity-100 logo-appear' : 'opacity-0'}`}
-          style={{ top: '130px' }}
+          className={`absolute w-[700px] transition-opacity duration-[3000ms] ${showLogo2 ? 'opacity-100 fade-in-right' : 'opacity-0'}`}
+          style={{ top: '25%' }}
         />
       </div>
       <div className="absolute bottom-8 flex flex-col items-center w-full">

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -187,3 +187,18 @@ img {
 .logo-appear {
     animation: logoAppear 1s ease-out forwards;
 }
+
+@keyframes fadeInRight {
+    from {
+        opacity: 0;
+        transform: translateX(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+.fade-in-right {
+    animation: fadeInRight 1s ease-out forwards;
+}


### PR DESCRIPTION
## Summary
- keep the start logo near the top by using `top: 25%`
- replace logo transition with new `fade-in-right` animation

## Testing
- `npm test` *(fails: mocha not found)*
- `npx mocha` *(fails: package download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68729aac47e4832a9a528df515a94d3a