### PR TITLE
Update logo placement and fade-in animation

### DIFF
--- a/frontend/src/components/HomeScreen.jsx
+++ b/frontend/src/components/HomeScreen.jsx
@@ -156,14 +156,14 @@ export default function HomeScreen() {
         <img
           src={logo1}
           alt="Kadir11"
-          className={`absolute w-[700px] transition-opacity duration-[10000ms] ${showLogo1 ? (showLogo2 ? 'opacity-0' : 'opacity-90 logo-appear') : 'opacity-0'}`}
-          style={{ mixBlendMode: 'screen', top: '25%' }}
+          className={`absolute w-[700px] transition-opacity duration-[10000ms] ${showLogo1 ? (showLogo2 ? 'opacity-0' : 'opacity-90 fade-in') : 'opacity-0'}`}
+          style={{ mixBlendMode: 'screen', top: '15%' }}
         />
         <img
           src={logo2}
           alt="Kadir11"
-          className={`absolute w-[700px] transition-opacity duration-[3000ms] ${showLogo2 ? 'opacity-100 fade-in-right' : 'opacity-0'}`}
-          style={{ top: '25%' }}
+          className={`absolute w-[700px] transition-opacity duration-[3000ms] ${showLogo2 ? 'opacity-100 fade-in' : 'opacity-0'}`}
+          style={{ top: '15%' }}
         />
       </div>
       <div className="absolute bottom-8 flex flex-col items-center w-full">

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -202,3 +202,16 @@ img {
 .fade-in-right {
     animation: fadeInRight 1s ease-out forwards;
 }
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+.fade-in {
+    animation: fadeIn 1s ease-out forwards;
+}


### PR DESCRIPTION
## Summary
- move logo higher on the home screen
- use a simple fade-in effect for logo display and swapping
- add global fade-in animation style

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` in frontend *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68729d1d192c832ab1d6562b56538e47