### PR TITLE
Adjust start logo position and swap animation

### DIFF
--- a/src/components/StartScreen.css
+++ b/src/components/StartScreen.css
@@ -19,7 +19,7 @@
 .start-logo {
   position: absolute;
   left: 50%;
-  top: 50%;
+  top: 25%;
   width: 300px;
   transform: translate(-50%, 50%);
   animation: logo-fade-up 1s forwards;
@@ -44,7 +44,7 @@
 @keyframes logo-fade-right {
   from {
     opacity: 0;
-    transform: translate(-150%, -50%);
+    transform: translate(150%, -50%);
   }
   to {
     opacity: 1;


### PR DESCRIPTION
## Summary
- move start-logo higher on the screen
- make replacement logo fade in from the right

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68729e9ae134832aae0eed4893a479d9