### PR TITLE
Add options modal and adjust logo animation

### DIFF
--- a/src/components/OptionsModal.css
+++ b/src/components/OptionsModal.css
@@ -1,0 +1,34 @@
+.options-modal__mask {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.6);
+  z-index: 40;
+}
+
+.options-modal__content {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: #222;
+  color: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  z-index: 41;
+  width: 280px;
+}
+
+.options-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.volume-control input[type='range'] {
+  flex-grow: 1;
+}
+
+.options-footer {
+  text-align: right;
+}

--- a/src/components/OptionsModal.tsx
+++ b/src/components/OptionsModal.tsx
@@ -1,0 +1,85 @@
+import { createPortal } from 'react-dom'
+import './OptionsModal.css'
+
+export interface Preferences {
+  language: 'PT-BR' | 'US'
+  fullscreen: boolean
+  volume: number
+  muted: boolean
+}
+
+interface Props {
+  open: boolean
+  preferences: Preferences
+  setPreferences: (p: Partial<Preferences>) => void
+  toggleMute: () => void
+  onClose: () => void
+}
+
+const OptionsModal = ({
+  open,
+  preferences,
+  setPreferences,
+  toggleMute,
+  onClose,
+}: Props) => {
+  if (!open) return null
+
+  return createPortal(
+    <div className='options-modal'>
+      <div className='options-modal__mask' onClick={onClose} />
+      <div className='options-modal__content'>
+        <h2>Opções</h2>
+        <div className='options-row'>
+          <label>
+            <input
+              type='radio'
+              value='PT-BR'
+              checked={preferences.language === 'PT-BR'}
+              onChange={() => setPreferences({ language: 'PT-BR' })}
+            />
+            PT-BR
+          </label>
+          <label>
+            <input
+              type='radio'
+              value='US'
+              checked={preferences.language === 'US'}
+              onChange={() => setPreferences({ language: 'US' })}
+            />
+            US
+          </label>
+        </div>
+        <div className='options-row'>
+          <label>
+            <input
+              type='checkbox'
+              checked={preferences.fullscreen}
+              onChange={e => setPreferences({ fullscreen: e.target.checked })}
+            />
+            Fullscreen
+          </label>
+        </div>
+        <div className='options-row volume-control'>
+          <button onClick={toggleMute}>{preferences.muted ? 'Unmute' : 'Mute'}</button>
+          <input
+            type='range'
+            min='0'
+            max='1'
+            step='0.01'
+            value={preferences.muted ? 0 : preferences.volume}
+            onChange={e =>
+              setPreferences({ volume: parseFloat(e.target.value), muted: false })
+            }
+          />
+        </div>
+        <div className='options-footer'>
+          <button onClick={onClose}>Fechar</button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+export default OptionsModal

--- a/src/components/StartScreen.css
+++ b/src/components/StartScreen.css
@@ -27,7 +27,7 @@
 }
 
 .logo-after {
-  animation: logo-fade-right 1s forwards;
+  animation: logo-fade-in 1s forwards;
 }
 
 @keyframes logo-fade-up {
@@ -41,14 +41,12 @@
   }
 }
 
-@keyframes logo-fade-right {
+@keyframes logo-fade-in {
   from {
     opacity: 0;
-    transform: translate(150%, -50%);
   }
   to {
     opacity: 1;
-    transform: translate(-50%, -50%);
   }
 }
 

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -1,10 +1,36 @@
 import { useEffect, useRef, useState } from 'react'
+import OptionsModal, { Preferences } from './OptionsModal'
 import './StartScreen.css'
 
 const StartScreen = () => {
   const audioRef = useRef<HTMLAudioElement>(null)
   const [logoSrc, setLogoSrc] = useState('assets/logo/kadirbefore.png')
   const [logoClass, setLogoClass] = useState('start-logo')
+  const [showOptions, setShowOptions] = useState(false)
+  const [prefs, setPrefs] = useState<Preferences>(() => {
+    const stored = localStorage.getItem('preferences')
+    return stored
+      ? JSON.parse(stored)
+      : { language: 'PT-BR', fullscreen: false, volume: 1, muted: false }
+  })
+  const lastVolumeRef = useRef(prefs.volume)
+
+  const updatePrefs = (update: Partial<Preferences>) => {
+    setPrefs(prev => {
+      const next = { ...prev, ...update }
+      localStorage.setItem('preferences', JSON.stringify(next))
+      return next
+    })
+  }
+
+  const toggleMute = () => {
+    if (prefs.muted) {
+      updatePrefs({ muted: false, volume: lastVolumeRef.current })
+    } else {
+      lastVolumeRef.current = prefs.volume
+      updatePrefs({ muted: true })
+    }
+  }
 
   useEffect(() => {
     const audioTimer = setTimeout(() => {
@@ -25,15 +51,36 @@ const StartScreen = () => {
     }
   }, [])
 
+  useEffect(() => {
+    if (audioRef.current) {
+      audioRef.current.volume = prefs.muted ? 0 : prefs.volume
+    }
+  }, [prefs.volume, prefs.muted])
+
+  useEffect(() => {
+    if (prefs.fullscreen) {
+      document.documentElement.requestFullscreen().catch(() => {})
+    } else if (document.fullscreenElement) {
+      document.exitFullscreen().catch(() => {})
+    }
+  }, [prefs.fullscreen])
+
   return (
     <div className='start-screen'>
       <video className='start-video' src='assets/logo/videointro.mp4' autoPlay loop muted />
       <img className={logoClass} src={logoSrc} alt='logo' />
       <div className='start-buttons'>
         <button>Iniciar</button>
-        <button>Opções</button>
+        <button onClick={() => setShowOptions(true)}>Opções</button>
         <button>Sair</button>
       </div>
+      <OptionsModal
+        open={showOptions}
+        preferences={prefs}
+        setPreferences={updatePrefs}
+        toggleMute={toggleMute}
+        onClose={() => setShowOptions(false)}
+      />
       <audio ref={audioRef} src='assets/sounds/sagadonorte.mp3' />
     </div>
   )


### PR DESCRIPTION
## Summary
- fade in replacement logo without movement
- implement OptionsModal for selecting language, fullscreen, and volume
- persist user preferences in localStorage
- hook up options modal in StartScreen

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872a2ffe688832aabfa771a59973f40