### PR TITLE
UI improvements and exit confirmation

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -121,3 +121,7 @@ ipcMain.handle('open-win', (_, arg) => {
     childWindow.loadFile(indexHtml, { hash: arg })
   }
 })
+
+ipcMain.handle('quit-app', () => {
+  app.quit()
+})

--- a/src/components/OptionsModal.css
+++ b/src/components/OptionsModal.css
@@ -16,11 +16,13 @@
   border-radius: 8px;
   z-index: 41;
   width: 280px;
+  text-align: center;
 }
 
 .options-row {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 10px;
   margin-bottom: 14px;
 }
@@ -31,4 +33,12 @@
 
 .options-footer {
   text-align: right;
+}
+
+.mute-btn {
+  background: transparent;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  color: #fff;
 }

--- a/src/components/OptionsModal.tsx
+++ b/src/components/OptionsModal.tsx
@@ -30,6 +30,7 @@ const OptionsModal = ({
       <div className='options-modal__mask' onClick={onClose} />
       <div className='options-modal__content'>
         <h2>Opções</h2>
+        <h3>Linguagem</h3>
         <div className='options-row'>
           <label>
             <input
@@ -50,6 +51,7 @@ const OptionsModal = ({
             US
           </label>
         </div>
+        <h3>Fullscreen</h3>
         <div className='options-row'>
           <label>
             <input
@@ -60,8 +62,9 @@ const OptionsModal = ({
             Fullscreen
           </label>
         </div>
+        <h3>Volume</h3>
         <div className='options-row volume-control'>
-          <button onClick={toggleMute}>{preferences.muted ? 'Unmute' : 'Mute'}</button>
+          <button className='mute-btn' onClick={toggleMute}>{preferences.muted ? '🔇' : '🔊'}</button>
           <input
             type='range'
             min='0'

--- a/src/components/StartScreen.css
+++ b/src/components/StartScreen.css
@@ -16,18 +16,21 @@
   z-index: -1;
 }
 
-.start-logo {
+
+.start-logos {
   position: absolute;
-  left: 50%;
   top: 25%;
-  width: 300px;
-  transform: translate(-50%, 50%);
-  animation: logo-fade-up 1s forwards;
-  animation-delay: 0.5s;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  gap: 40px;
 }
 
-.logo-after {
+.logo-img {
+  width: 300px;
+  opacity: 0;
   animation: logo-fade-in 1s forwards;
+  animation-delay: 0.5s;
 }
 
 @keyframes logo-fade-up {
@@ -66,5 +69,36 @@
   color: #fff;
   padding: 0.8em 1.5em;
   border: none;
+}
+
+.exit-dropdown {
+  position: absolute;
+  bottom: 110px;
+  left: 50%;
+  transform: translate(-50%, 20px);
+  background-color: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  padding: 12px;
+  border-radius: 8px;
+  text-align: center;
+  animation: dropdown 0.3s forwards;
+}
+
+.exit-buttons {
+  margin-top: 8px;
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+}
+
+@keyframes dropdown {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 20px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
 }
 

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -4,9 +4,8 @@ import './StartScreen.css'
 
 const StartScreen = () => {
   const audioRef = useRef<HTMLAudioElement>(null)
-  const [logoSrc, setLogoSrc] = useState('assets/logo/kadirbefore.png')
-  const [logoClass, setLogoClass] = useState('start-logo')
   const [showOptions, setShowOptions] = useState(false)
+  const [showExitConfirm, setShowExitConfirm] = useState(false)
   const [prefs, setPrefs] = useState<Preferences>(() => {
     const stored = localStorage.getItem('preferences')
     return stored
@@ -40,14 +39,8 @@ const StartScreen = () => {
       }
     }, 2000)
 
-    const logoTimer = setTimeout(() => {
-      setLogoSrc('assets/logo/kadirafter.png')
-      setLogoClass('start-logo logo-after')
-    }, 3000)
-
     return () => {
       clearTimeout(audioTimer)
-      clearTimeout(logoTimer)
     }
   }, [])
 
@@ -68,12 +61,24 @@ const StartScreen = () => {
   return (
     <div className='start-screen'>
       <video className='start-video' src='assets/logo/videointro.mp4' autoPlay loop muted />
-      <img className={logoClass} src={logoSrc} alt='logo' />
+      <div className='start-logos'>
+        <img className='logo-img' src='assets/logo/kadirbefore.png' alt='logo1' />
+        <img className='logo-img' src='assets/logo/kadir11.png' alt='logo2' />
+      </div>
       <div className='start-buttons'>
         <button>Iniciar</button>
         <button onClick={() => setShowOptions(true)}>Opções</button>
-        <button>Sair</button>
+        <button onClick={() => setShowExitConfirm(true)}>Sair</button>
       </div>
+      {showExitConfirm && (
+        <div className='exit-dropdown'>
+          <p>Deseja sair?</p>
+          <div className='exit-buttons'>
+            <button onClick={() => window.ipcRenderer.invoke('quit-app')}>Sim</button>
+            <button onClick={() => setShowExitConfirm(false)}>Não</button>
+          </div>
+        </div>
+      )}
       <OptionsModal
         open={showOptions}
         preferences={prefs}


### PR DESCRIPTION
## Summary
- polish options modal layout and use icons for mute control
- display two logos side by side with fade-in animation
- add exit confirmation dropdown and wire quit message
- centralize modal controls

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872a500b2e4832a8fadee148738cbe8