### PR TITLE
Implement logo fade and centered exit modal

### DIFF
--- a/src/components/StartScreen.css
+++ b/src/components/StartScreen.css
@@ -17,40 +17,25 @@
 }
 
 
+
 .start-logos {
   position: absolute;
   top: 25%;
   left: 50%;
   transform: translate(-50%, -50%);
-  display: flex;
-  gap: 40px;
 }
 
 .logo-img {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
   width: 300px;
   opacity: 0;
-  animation: logo-fade-in 1s forwards;
-  animation-delay: 0.5s;
+  transition: opacity 1s ease;
 }
 
-@keyframes logo-fade-up {
-  from {
-    opacity: 0;
-    transform: translate(-50%, 50%);
-  }
-  to {
-    opacity: 1;
-    transform: translate(-50%, -50%);
-  }
-}
-
-@keyframes logo-fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
+.logo-img.visible {
+  opacity: 1;
 }
 
 .start-buttons {
@@ -72,10 +57,10 @@
 }
 
 .exit-dropdown {
-  position: absolute;
-  bottom: 110px;
+  position: fixed;
+  top: 50%;
   left: 50%;
-  transform: translate(-50%, 20px);
+  transform: translate(-50%, -50%);
   background-color: rgba(0, 0, 0, 0.8);
   color: #fff;
   padding: 12px;
@@ -94,11 +79,11 @@
 @keyframes dropdown {
   from {
     opacity: 0;
-    transform: translate(-50%, 20px);
+    transform: translate(-50%, -60%);
   }
   to {
     opacity: 1;
-    transform: translate(-50%, 0);
+    transform: translate(-50%, -50%);
   }
 }
 

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -6,6 +6,8 @@ const StartScreen = () => {
   const audioRef = useRef<HTMLAudioElement>(null)
   const [showOptions, setShowOptions] = useState(false)
   const [showExitConfirm, setShowExitConfirm] = useState(false)
+  const [showLogoBefore, setShowLogoBefore] = useState(false)
+  const [showLogoAfter, setShowLogoAfter] = useState(false)
   const [prefs, setPrefs] = useState<Preferences>(() => {
     const stored = localStorage.getItem('preferences')
     return stored
@@ -58,12 +60,32 @@ const StartScreen = () => {
     }
   }, [prefs.fullscreen])
 
+  useEffect(() => {
+    const timerBefore = setTimeout(() => setShowLogoBefore(true), 2000)
+    const timerAfter = setTimeout(() => {
+      setShowLogoBefore(false)
+      setShowLogoAfter(true)
+    }, 4000)
+    return () => {
+      clearTimeout(timerBefore)
+      clearTimeout(timerAfter)
+    }
+  }, [])
+
   return (
     <div className='start-screen'>
       <video className='start-video' src='assets/logo/videointro.mp4' autoPlay loop muted />
       <div className='start-logos'>
-        <img className='logo-img' src='assets/logo/kadirbefore.png' alt='logo1' />
-        <img className='logo-img' src='assets/logo/kadir11.png' alt='logo2' />
+        <img
+          className={`logo-img ${showLogoBefore ? 'visible' : ''}`}
+          src='assets/logo/kadirbefore.png'
+          alt='logo1'
+        />
+        <img
+          className={`logo-img ${showLogoAfter ? 'visible' : ''}`}
+          src='assets/logo/kadirafter.png'
+          alt='logo2'
+        />
       </div>
       <div className='start-buttons'>
         <button>Iniciar</button>


### PR DESCRIPTION
## Summary
- center the exit confirmation modal
- add timed fade-in logo sequence

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872a9ea0e3c832aa849fdaed95f414f