### PR TITLE
Improve start screen layout and add translations

### DIFF
--- a/src/components/OptionsModal.tsx
+++ b/src/components/OptionsModal.tsx
@@ -1,4 +1,5 @@
 import { createPortal } from 'react-dom'
+import { t } from '@/locales'
 import './OptionsModal.css'
 
 export interface Preferences {
@@ -29,8 +30,8 @@ const OptionsModal = ({
     <div className='options-modal'>
       <div className='options-modal__mask' onClick={onClose} />
       <div className='options-modal__content'>
-        <h2>Opções</h2>
-        <h3>Linguagem</h3>
+        <h2>{t(preferences.language, 'optionsTitle')}</h2>
+        <h3>{t(preferences.language, 'language')}</h3>
         <div className='options-row'>
           <label>
             <input
@@ -51,7 +52,7 @@ const OptionsModal = ({
             US
           </label>
         </div>
-        <h3>Fullscreen</h3>
+        <h3>{t(preferences.language, 'fullscreen')}</h3>
         <div className='options-row'>
           <label>
             <input
@@ -59,10 +60,10 @@ const OptionsModal = ({
               checked={preferences.fullscreen}
               onChange={e => setPreferences({ fullscreen: e.target.checked })}
             />
-            Fullscreen
+            {t(preferences.language, 'fullscreen')}
           </label>
         </div>
-        <h3>Volume</h3>
+        <h3>{t(preferences.language, 'volume')}</h3>
         <div className='options-row volume-control'>
           <button className='mute-btn' onClick={toggleMute}>{preferences.muted ? '🔇' : '🔊'}</button>
           <input
@@ -77,7 +78,7 @@ const OptionsModal = ({
           />
         </div>
         <div className='options-footer'>
-          <button onClick={onClose}>Fechar</button>
+          <button onClick={onClose}>{t(preferences.language, 'close')}</button>
         </div>
       </div>
     </div>,

--- a/src/components/StartScreen.css
+++ b/src/components/StartScreen.css
@@ -20,7 +20,7 @@
 
 .start-logos {
   position: absolute;
-  top: 25%;
+  top: 15%;
   left: 50%;
   transform: translate(-50%, -50%);
 }

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import OptionsModal, { Preferences } from './OptionsModal'
+import { t } from '@/locales'
 import './StartScreen.css'
 
 const StartScreen = () => {
@@ -61,7 +62,7 @@ const StartScreen = () => {
   }, [prefs.fullscreen])
 
   useEffect(() => {
-    const timerBefore = setTimeout(() => setShowLogoBefore(true), 2000)
+    const timerBefore = setTimeout(() => setShowLogoBefore(true), 1300)
     const timerAfter = setTimeout(() => {
       setShowLogoBefore(false)
       setShowLogoAfter(true)
@@ -88,16 +89,16 @@ const StartScreen = () => {
         />
       </div>
       <div className='start-buttons'>
-        <button>Iniciar</button>
-        <button onClick={() => setShowOptions(true)}>Opções</button>
-        <button onClick={() => setShowExitConfirm(true)}>Sair</button>
+        <button>{t(prefs.language, 'start')}</button>
+        <button onClick={() => setShowOptions(true)}>{t(prefs.language, 'options')}</button>
+        <button onClick={() => setShowExitConfirm(true)}>{t(prefs.language, 'exit')}</button>
       </div>
       {showExitConfirm && (
         <div className='exit-dropdown'>
-          <p>Deseja sair?</p>
+          <p>{t(prefs.language, 'exitConfirm')}</p>
           <div className='exit-buttons'>
-            <button onClick={() => window.ipcRenderer.invoke('quit-app')}>Sim</button>
-            <button onClick={() => setShowExitConfirm(false)}>Não</button>
+            <button onClick={() => window.ipcRenderer.invoke('quit-app')}>{t(prefs.language, 'exitYes')}</button>
+            <button onClick={() => setShowExitConfirm(false)}>{t(prefs.language, 'exitNo')}</button>
           </div>
         </div>
       )}

--- a/src/locales.ts
+++ b/src/locales.ts
@@ -1,0 +1,35 @@
+export const translations = {
+  'PT-BR': {
+    start: 'Iniciar',
+    options: 'Opções',
+    exit: 'Sair',
+    exitConfirm: 'Deseja realmente sair?',
+    exitYes: 'Sim',
+    exitNo: 'Não',
+    optionsTitle: 'Opções',
+    language: 'Linguagem',
+    fullscreen: 'Fullscreen',
+    volume: 'Volume',
+    close: 'Fechar',
+  },
+  US: {
+    start: 'Start',
+    options: 'Options',
+    exit: 'Exit',
+    exitConfirm: 'Are you sure you want to exit?',
+    exitYes: 'Yes',
+    exitNo: 'No',
+    optionsTitle: 'Options',
+    language: 'Language',
+    fullscreen: 'Fullscreen',
+    volume: 'Volume',
+    close: 'Close',
+  },
+} as const
+
+export type Lang = keyof typeof translations
+export type TranslationKey = keyof typeof translations['PT-BR']
+
+export function t(lang: Lang, key: TranslationKey): string {
+  return translations[lang][key]
+}


### PR DESCRIPTION
## Summary
- adjust logo positioning on the start screen
- start logo fade-in sooner
- translate UI to English when selected

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872ac32c158832a9a80cfe7f81c57c9