### PR TITLE
Add shine effect to logo

### DIFF
--- a/src/components/StartScreen.css
+++ b/src/components/StartScreen.css
@@ -25,18 +25,57 @@
   transform: translate(-50%, -50%);
 }
 
-.logo-img {
+
+.logo-container {
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
   width: 300px;
+}
+
+.logo-container img {
+  display: block;
+  width: 100%;
+  height: auto;
+  position: relative;
+  z-index: 1;
   opacity: 0;
   transition: opacity 1s ease;
 }
 
-.logo-img.visible {
+.logo-container img.visible {
   opacity: 1;
 }
+
+.shine-effect {
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  background: linear-gradient(
+    120deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.8) 50%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  transform: skewX(-20deg);
+  animation: shine 2.5s infinite;
+  mix-blend-mode: color-dodge;
+  opacity: 0.6;
+  z-index: 2;
+}
+
+@keyframes shine {
+  0% {
+    left: -100%;
+  }
+  100% {
+    left: 100%;
+  }
+}
+
 
 .start-buttons {
   position: absolute;

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -9,6 +9,7 @@ const StartScreen = () => {
   const [showExitConfirm, setShowExitConfirm] = useState(false)
   const [showLogoBefore, setShowLogoBefore] = useState(false)
   const [showLogoAfter, setShowLogoAfter] = useState(false)
+  const [showShine, setShowShine] = useState(false)
   const [prefs, setPrefs] = useState<Preferences>(() => {
     const stored = localStorage.getItem('preferences')
     return stored
@@ -73,20 +74,32 @@ const StartScreen = () => {
     }
   }, [])
 
+  useEffect(() => {
+    if (showLogoAfter) {
+      const timer = setTimeout(() => setShowShine(true), 1000)
+      return () => clearTimeout(timer)
+    }
+  }, [showLogoAfter])
+
   return (
     <div className='start-screen'>
       <video className='start-video' src='assets/logo/videointro.mp4' autoPlay loop muted />
       <div className='start-logos'>
-        <img
-          className={`logo-img ${showLogoBefore ? 'visible' : ''}`}
-          src='assets/logo/kadirbefore.png'
-          alt='logo1'
-        />
-        <img
-          className={`logo-img ${showLogoAfter ? 'visible' : ''}`}
-          src='assets/logo/kadirafter.png'
-          alt='logo2'
-        />
+        <div className='logo-container'>
+          <img
+            className={`logo-img ${showLogoBefore ? 'visible' : ''}`}
+            src='assets/logo/kadirbefore.png'
+            alt='logo1'
+          />
+        </div>
+        <div className='logo-container'>
+          <img
+            className={`logo-img ${showLogoAfter ? 'visible' : ''}`}
+            src='assets/logo/kadirafter.png'
+            alt='logo2'
+          />
+          {showShine && <div className='shine-effect' />}
+        </div>
       </div>
       <div className='start-buttons'>
         <button>{t(prefs.language, 'start')}</button>


### PR DESCRIPTION
## Summary
- add a shine effect to the new logo after the fade transition completes

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872f5b82f4c832a8dd3eda2313ad3a6