### PR TITLE
Add shine animation overlay to HomeScreen logo

### DIFF
--- a/frontend/src/components/HomeScreen.jsx
+++ b/frontend/src/components/HomeScreen.jsx
@@ -165,11 +165,9 @@ export default function HomeScreen() {
       />
       <audio ref={audioRef} src={musicSrc} loop className="hidden" />
       <div className="relative w-[700px] h-[700px]">
-        <img
-          src={logo1}
-          alt="Kadir11"
-          className={`absolute w-[700px] transition-opacity duration-1000 ${showLogo1 ? (showLogo2 ? 'opacity-0' : 'opacity-100') : 'opacity-0'}`}
-          style={{ mixBlendMode: 'screen', top: '15%' }}
+        <div
+          className={`absolute w-[700px] h-[700px] logo-shine transition-opacity duration-1000 ${showLogo1 ? (showLogo2 ? 'opacity-0' : 'opacity-100') : 'opacity-0'}`}
+          style={{ top: '15%', maskImage: `url(${logo1})`, WebkitMaskImage: `url(${logo1})` }}
         />
         <img
           src={logo2}

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -215,3 +215,24 @@ img {
 .fade-in {
     animation: fadeIn 1s ease-out forwards;
 }
+
+@keyframes shine {
+    from {
+        background-position: -200% 0;
+    }
+    to {
+        background-position: 200% 0;
+    }
+}
+
+.logo-shine {
+    background: linear-gradient(60deg, transparent 25%, rgba(255,255,255,0.8) 50%, transparent 75%);
+    background-size: 200% 100%;
+    mask-repeat: no-repeat;
+    mask-size: contain;
+    mask-position: center;
+    -webkit-mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    -webkit-mask-position: center;
+    animation: shine 1.5s linear infinite;
+}


### PR DESCRIPTION
## Summary
- animate a shine effect using CSS masking
- overlay animated shine over the Kadir11 logo

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6872fc8f1028832a88a523334ac7984a