### PR TITLE
Add logo transition with shine effect

### DIFF
--- a/src/components/StartScreen.css
+++ b/src/components/StartScreen.css
@@ -37,7 +37,9 @@
   display: block;
   width: 100%;
   height: auto;
-  position: relative;
+  position: absolute;
+  top: 0;
+  left: 0;
   z-index: 1;
   opacity: 0;
   transition: opacity 1s ease;

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -7,6 +7,7 @@ const StartScreen = () => {
   const audioRef = useRef<HTMLAudioElement>(null)
   const [showOptions, setShowOptions] = useState(false)
   const [showExitConfirm, setShowExitConfirm] = useState(false)
+  const [showLogoBefore, setShowLogoBefore] = useState(false)
   const [showLogoAfter, setShowLogoAfter] = useState(false)
   const [showShine, setShowShine] = useState(false)
   const [prefs, setPrefs] = useState<Preferences>(() => {
@@ -62,22 +63,30 @@ const StartScreen = () => {
   }, [prefs.fullscreen])
 
   useEffect(() => {
-    const timer = setTimeout(() => setShowLogoAfter(true), 4000)
-    return () => clearTimeout(timer)
-  }, [])
+    const beforeTimer = setTimeout(() => setShowLogoBefore(true), 2000)
+    const afterTimer = setTimeout(() => {
+      setShowLogoBefore(false)
+      setShowLogoAfter(true)
+    }, 4000)
+    const shineTimer = setTimeout(() => setShowShine(true), 6000)
 
-  useEffect(() => {
-    if (showLogoAfter) {
-      const timer = setTimeout(() => setShowShine(true), 1000)
-      return () => clearTimeout(timer)
+    return () => {
+      clearTimeout(beforeTimer)
+      clearTimeout(afterTimer)
+      clearTimeout(shineTimer)
     }
-  }, [showLogoAfter])
+  }, [])
 
   return (
     <div className='start-screen'>
       <video className='start-video' src='assets/logo/videointro.mp4' autoPlay loop muted />
       <div className='start-logos'>
         <div className='logo-container'>
+          <img
+            className={`logo-img ${showLogoBefore ? 'visible' : ''}`}
+            src='assets/logo/kadirbefore.png'
+            alt='logo1'
+          />
           <img
             className={`logo-img ${showLogoAfter ? 'visible' : ''}`}
             src='assets/logo/kadirafter.png'


### PR DESCRIPTION
## Summary
- display the `kadirbefore.png` logo first, then fade to `kadirafter.png`
- after showing the second logo, apply a masked shine animation
- position logo images absolutely for smooth crossfades

## Testing
- `npm test` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873010eca40832a91d4b13b307194d5