### PR TITLE
Expand shine overlay outside logo

### DIFF
--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -98,6 +98,10 @@ const StartScreen = () => {
               style={{
                 WebkitMaskImage: "url('assets/logo/kadirafter.png')",
                 maskImage: "url('assets/logo/kadirafter.png')",
+                WebkitMaskRepeat: 'no-repeat',
+                maskRepeat: 'no-repeat',
+                WebkitMaskPosition: 'center',
+                maskPosition: 'center',
               }}
             />
           )}

--- a/src/index.css
+++ b/src/index.css
@@ -104,7 +104,10 @@ code {
 
 .logo-shine {
   position: absolute;
-  inset: 0;
+  top: 0;
+  left: -100%;
+  width: 300%;
+  height: 100%;
   background: linear-gradient(
       120deg,
       rgba(255, 255, 255, 0) 0%,


### PR DESCRIPTION
## Summary
- enlarge the shine overlay outside the logo container
- keep the shine only visible within the logo using CSS mask

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873032123a4832a9df3ceffaf351806