### PR TITLE
Add shine effect overlay

### DIFF
--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -94,7 +94,7 @@ const StartScreen = () => {
           />
           {showShine && (
             <div
-              className='logo-img logo-shine'
+              className='logo-img shine-effect'
               style={{
                 WebkitMaskImage: "url('assets/logo/kadirafter.png')",
                 maskImage: "url('assets/logo/kadirafter.png')",

--- a/src/index.css
+++ b/src/index.css
@@ -102,20 +102,22 @@ code {
   }
 }
 
-.logo-shine {
+.shine-effect {
   position: absolute;
   top: 0;
   left: -100%;
-  width: 300%;
+  width: 100%;
   height: 100%;
+  pointer-events: none;
   background: linear-gradient(
       120deg,
       rgba(255, 255, 255, 0) 0%,
       rgba(255, 255, 255, 0.8) 50%,
       rgba(255, 255, 255, 0) 100%
     );
-  background-size: 200% 100%;
+  transform: skewX(-20deg);
   animation: shine 2.5s infinite;
-  pointer-events: none;
+  mix-blend-mode: screen;
+  opacity: 0.6;
   z-index: 2;
 }


### PR DESCRIPTION
## Summary
- update StartScreen logo overlay to use new `shine-effect`
- style `.shine-effect` with gradient animation

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68730597e760832ab3f701d36d1319d3