### PR TITLE
Fix shine effect overlay

### DIFF
--- a/src/components/StartScreen.css
+++ b/src/components/StartScreen.css
@@ -31,6 +31,7 @@
   left: 50%;
   transform: translateX(-50%);
   width: 300px;
+  height: 300px;
 }
 
 .logo-container .logo-img {

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -94,7 +94,7 @@ const StartScreen = () => {
           />
           {showShine && (
             <div
-              className='logo-img shine-effect'
+              className='shine-effect'
               style={{
                 WebkitMaskImage: "url('assets/logo/kadirafter.png')",
                 maskImage: "url('assets/logo/kadirafter.png')",


### PR DESCRIPTION
## Summary
- fix shine effect position by removing `logo-img` class
- define dimensions for the logo container

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873a064b138832a9a58073b471b7678