### PR TITLE
Add character creation UI

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, shell, ipcMain } from 'electron'
+import Store from 'electron-store'
 import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
@@ -124,4 +125,10 @@ ipcMain.handle('open-win', (_, arg) => {
 
 ipcMain.handle('quit-app', () => {
   app.quit()
+})
+
+const store = new Store()
+
+ipcMain.handle('save-character', (_event, data) => {
+  store.set('selectedCharacter', data)
 })

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "electron-store": "^8.1.0",
     "electron-updater": "^6.3.9"
   },
   "devDependencies": {

--- a/src/components/CharacterCreation.css
+++ b/src/components/CharacterCreation.css
@@ -1,0 +1,38 @@
+.character-creation {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.character-creation canvas {
+  border: 1px solid #fff;
+  margin-bottom: 12px;
+}
+
+.character-creation .fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
+.character-creation label {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+}
+
+.character-creation select,
+.character-creation input {
+  padding: 4px;
+  background-color: #1a1a1a;
+  color: #fff;
+  border: 1px solid #555;
+  border-radius: 4px;
+}
+
+.character-creation .confirm {
+  margin-top: 12px;
+  padding: 6px 12px;
+}

--- a/src/components/CharacterCreation.tsx
+++ b/src/components/CharacterCreation.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useRef, useState } from 'react'
+import './CharacterCreation.css'
+
+export interface CharacterSelection {
+  sex: 'male' | 'female'
+  skin: string
+  eyes: string
+  torso: string
+  legs: string
+  feet: string
+  shoulders: string
+  cape: string
+  hair: { style: string; color: string }
+  hat: string
+  accessory: string
+  name: string
+}
+
+const defaultSelection: CharacterSelection = {
+  sex: 'male',
+  skin: '',
+  eyes: '',
+  torso: '',
+  legs: '',
+  feet: '',
+  shoulders: '',
+  cape: '',
+  hair: { style: '', color: '' },
+  hat: '',
+  accessory: '',
+  name: '',
+}
+
+const frameWidth = 64
+const frameHeight = 64
+const sx = 1 * frameWidth
+const sy = 3 * frameHeight
+
+export default function CharacterCreation() {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [metadata, setMetadata] = useState<any>(null)
+  const [selection, setSelection] = useState<CharacterSelection>(defaultSelection)
+
+  useEffect(() => {
+    fetch('Assets/Character/character_metadata_final.json')
+      .then(res => res.json())
+      .then(setMetadata)
+      .catch(err => console.error(err))
+  }, [])
+
+  useEffect(() => {
+    const ctx = canvasRef.current?.getContext('2d')
+    if (!ctx) return
+    ctx.clearRect(0, 0, frameWidth, frameHeight)
+    const drawLayer = (src?: string) => {
+      if (!src) return
+      const img = new Image()
+      img.src = src
+      img.onload = () => {
+        ctx.drawImage(img, sx, sy, frameWidth, frameHeight, 0, 0, frameWidth, frameHeight)
+      }
+    }
+    drawLayer(selection.skin)
+    drawLayer(selection.eyes)
+    drawLayer(selection.legs)
+    drawLayer(selection.feet)
+    drawLayer(selection.torso)
+    drawLayer(selection.shoulders)
+    drawLayer(selection.cape)
+    drawLayer(selection.hair.style)
+    drawLayer(selection.hair.color)
+    drawLayer(selection.hat)
+    drawLayer(selection.accessory)
+  }, [selection])
+
+  const handle = (field: keyof CharacterSelection, value: any) => {
+    setSelection(prev => ({ ...prev, [field]: value }))
+  }
+
+  const handleHair = (field: 'style' | 'color', value: string) => {
+    setSelection(prev => ({ ...prev, hair: { ...prev.hair, [field]: value } }))
+  }
+
+  const confirm = () => {
+    window.ipcRenderer.invoke('save-character', selection)
+  }
+
+  const list = (key: string) => metadata?.[key] ?? []
+  const listSex = (key: string) => metadata?.[key]?.[selection.sex] ?? []
+
+  return (
+    <div className='character-creation'>
+      <canvas ref={canvasRef} width={frameWidth} height={frameHeight} />
+      <div className='fields'>
+        <label>
+          Sexo
+          <select value={selection.sex} onChange={e => handle('sex', e.target.value as 'male' | 'female')}>
+            <option value='male'>male</option>
+            <option value='female'>female</option>
+          </select>
+        </label>
+        <label>
+          Pele
+          <select value={selection.skin} onChange={e => handle('skin', e.target.value)}>
+            <option value=''>-</option>
+            {list('skin').map((o: string) => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Olhos
+          <select value={selection.eyes} onChange={e => handle('eyes', e.target.value)}>
+            <option value=''>-</option>
+            {list('eyes').map((o: string) => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Torso
+          <select value={selection.torso} onChange={e => handle('torso', e.target.value)}>
+            <option value=''>-</option>
+            {listSex('torso').map((o: string) => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Pernas
+          <select value={selection.legs} onChange={e => handle('legs', e.target.value)}>
+            <option value=''>-</option>
+            {listSex('legs').map((o: string) => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Pés
+          <select value={selection.feet} onChange={e => handle('feet', e.target.value)}>
+            <option value=''>-</option>
+            {listSex('feet').map((o: string) => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Ombros
+          <select value={selection.shoulders} onChange={e => handle('shoulders', e.target.value)}>
+            <option value=''>-</option>
+            {list('shoulders').map((o: string) => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Capa
+          <select value={selection.cape} onChange={e => handle('cape', e.target.value)}>
+            <option value=''>-</option>
+            {list('cape').map((o: string) => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Cabelo Estilo
+          <select value={selection.hair.style} onChange={e => handleHair('style', e.target.value)}>
+            <option value=''>-</option>
+            {list('hairStyle').map((o: string) => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Cabelo Cor
+          <select value={selection.hair.color} onChange={e => handleHair('color', e.target.value)}>
+            <option value=''>-</option>
+            {list('hairColor').map((o: string) => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Chapéu
+          <select value={selection.hat} onChange={e => handle('hat', e.target.value)}>
+            <option value=''>-</option>
+            {list('hat').map((o: string) => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Acessório
+          <select value={selection.accessory} onChange={e => handle('accessory', e.target.value)}>
+            <option value=''>-</option>
+            {list('accessory').map((o: string) => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Nome
+          <input value={selection.name} onChange={e => handle('name', e.target.value)} />
+        </label>
+        <button className='confirm' onClick={confirm}>Confirmar</button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/StartScreen.css
+++ b/src/components/StartScreen.css
@@ -101,3 +101,44 @@
   }
 }
 
+
+.intro-screen {
+  position: fixed;
+  inset: 0;
+  background: #000;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.intro-text {
+  opacity: 0;
+  transition: opacity 1s ease;
+}
+
+.intro-text.visible {
+  opacity: 1;
+}
+
+.proceed-btn {
+  margin-top: 20px;
+  padding: 0.6em 1.2em;
+  background: #1a1a1a;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+}
+
+.creator-container {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+}
+
+.creator-container.visible {
+  opacity: 1;
+  transform: translateY(0);
+}

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import OptionsModal, { Preferences } from './OptionsModal'
+import CharacterCreation from './CharacterCreation'
 import { t } from '@/locales'
 import './StartScreen.css'
 
@@ -17,6 +18,15 @@ const StartScreen = () => {
       : { language: 'PT-BR', fullscreen: false, volume: 1, muted: false }
   })
   const lastVolumeRef = useRef(prefs.volume)
+
+  const [phase, setPhase] = useState<'menu' | 'intro' | 'create'>('menu')
+  const [messageIndex, setMessageIndex] = useState(0)
+  const messages = [
+    'Boas vindas, viajante...',
+    'Parece estar cansado, mas não desanime.',
+    'Kadir está aqui.',
+    'Vamos conhecer um pouco mais sobre você.',
+  ]
 
   const updatePrefs = (update: Partial<Preferences>) => {
     setPrefs(prev => {
@@ -47,6 +57,13 @@ const StartScreen = () => {
       clearTimeout(audioTimer)
     }
   }, [])
+
+  useEffect(() => {
+    if (phase !== 'intro') return
+    if (messageIndex >= messages.length) return
+    const timer = setTimeout(() => setMessageIndex(i => i + 1), 2000)
+    return () => clearTimeout(timer)
+  }, [phase, messageIndex])
 
   useEffect(() => {
     if (audioRef.current) {
@@ -107,10 +124,27 @@ const StartScreen = () => {
           )}
         </div>
       </div>
-      <div className='start-buttons'>
-        <button>{t(prefs.language, 'start')}</button>
-        <button onClick={() => setShowOptions(true)}>{t(prefs.language, 'options')}</button>
-        <button onClick={() => setShowExitConfirm(true)}>{t(prefs.language, 'exit')}</button>
+      {phase === 'menu' && (
+        <div className='start-buttons'>
+          <button onClick={() => { setPhase('intro'); setMessageIndex(0) }}>
+            {t(prefs.language, 'start')}
+          </button>
+          <button onClick={() => setShowOptions(true)}>{t(prefs.language, 'options')}</button>
+          <button onClick={() => setShowExitConfirm(true)}>{t(prefs.language, 'exit')}</button>
+        </div>
+      )}
+      {phase === 'intro' && (
+        <div className='intro-screen'>
+          {messages.map((m, i) => (
+            <p key={i} className={`intro-text ${messageIndex > i ? 'visible' : ''}`}>{m}</p>
+          ))}
+          {messageIndex >= messages.length && (
+            <button className='proceed-btn' onClick={() => setPhase('create')}>Prosseguir</button>
+          )}
+        </div>
+      )}
+      <div className={`creator-container ${phase === 'create' ? 'visible' : ''}`}> 
+        {phase === 'create' && <CharacterCreation />}
       </div>
       {showExitConfirm && (
         <div className='exit-dropdown'>


### PR DESCRIPTION
## Summary
- introduce `CharacterCreation` component with canvas layering
- extend `StartScreen` to show an intro and allow character creation
- persist selected character using electron-store
- add basic styles for the new screens

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c821a490832abae7b27e25c5c77c