### PR TITLE
Update character creation layout

### DIFF
--- a/src/components/CharacterCreation.css
+++ b/src/components/CharacterCreation.css
@@ -1,8 +1,9 @@
 .character-creation {
   margin-top: 20px;
   display: flex;
-  flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 20px;
 }
 
 .character-creation canvas {
@@ -15,9 +16,9 @@
 
 .character-creation .fields {
   display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  justify-content: center;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
 }
 
 .character-creation label {
@@ -44,8 +45,8 @@
 }
 
 .option-label {
-  width: 100px;
-  text-align: right;
+  min-width: 80px;
+  text-align: center;
 }
 
 .arrow-btn {
@@ -56,9 +57,16 @@
   border-radius: 4px;
 }
 
-.option-value {
-  min-width: 80px;
+.nickname {
+  margin-top: 8px;
   text-align: center;
+  color: #fff;
+}
+
+.preview {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .name-row {

--- a/src/components/CharacterCreation.tsx
+++ b/src/components/CharacterCreation.tsx
@@ -18,7 +18,7 @@ export interface CharacterSelection {
 
 const defaultSelection: CharacterSelection = {
   sex: 'male',
-  skin: '',
+  skin: 'Assets/Character/body/male/light.png',
   eyes: '',
   torso: '',
   legs: '',
@@ -57,12 +57,10 @@ function OptionRow({ label, options, value, onChange, allowNone = true }: Option
     const i = (index + 1) % all.length
     onChange(all[i])
   }
-  const display = value || '-'
   return (
     <div className='option-row'>
-      <span className='option-label'>{label}</span>
       <button className='arrow-btn' onClick={prev}>◀</button>
-      <span className='option-value'>{display}</span>
+      <span className='option-label'>{label}</span>
       <button className='arrow-btn' onClick={next}>▶</button>
     </div>
   )
@@ -149,7 +147,6 @@ export default function CharacterCreation() {
 
   return (
     <div className='character-creation'>
-      <canvas ref={canvasRef} width={frameWidth} height={frameHeight} />
       <div className='fields'>
         <OptionRow
           label='Sexo'
@@ -224,10 +221,14 @@ export default function CharacterCreation() {
           value={selection.accessory}
           onChange={v => handle('accessory', v)}
         />
+      </div>
+      <div className='preview'>
+        <canvas ref={canvasRef} width={frameWidth} height={frameHeight} />
         <label className='name-row'>
           Nome
           <input value={selection.name} onChange={e => handle('name', e.target.value)} />
         </label>
+        <div className='nickname'>{selection.name}</div>
         <button className='confirm' onClick={confirm}>Confirmar</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- default to male with light skin
- simplify option rows so only arrows and labels show
- place attribute list on the left and character preview with nickname on the right

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873efa48ccc832a91b17161b3e449c3