### PR TITLE
Add gender selection step

### DIFF
--- a/frontend/src/components/ElementPage.jsx
+++ b/frontend/src/components/ElementPage.jsx
@@ -6,14 +6,15 @@ export default function ElementPage() {
   const navigate = useNavigate()
   const { state } = useLocation()
   const name = state?.name
+  const gender = state?.gender
   const stats = state?.stats
 
   useEffect(() => {
-    if (!name || !stats) navigate('/intro')
-  }, [name, stats, navigate])
+    if (!name || !gender || !stats) navigate('/intro')
+  }, [name, gender, stats, navigate])
 
   const handleSelect = (finalStats) => {
-    const pet = { name, ...finalStats }
+    const pet = { name, gender, ...finalStats }
     if (window.api?.setPreference) {
       window.api.setPreference('pet', pet)
     } else {
@@ -22,7 +23,7 @@ export default function ElementPage() {
     navigate('/')
   }
 
-  if (!name || !stats) return null
+  if (!name || !gender || !stats) return null
 
   return (
     <div className="flex items-center justify-center h-full">

--- a/frontend/src/components/IntroPage.jsx
+++ b/frontend/src/components/IntroPage.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom'
 export default function IntroPage() {
   const [name, setName] = useState('')
   const [confirmed, setConfirmed] = useState(false)
+  const [gender, setGender] = useState('')
   const navigate = useNavigate()
 
   const handleChange = (e) => {
@@ -17,7 +18,8 @@ export default function IntroPage() {
   }
 
   const handleProceed = () => {
-    navigate('/questions', { state: { name } })
+    if (!gender) return
+    navigate('/questions', { state: { name, gender } })
   }
 
   return (
@@ -52,8 +54,30 @@ export default function IntroPage() {
           O destino o trouxe até{' '}
           <span className="text-yellow-400">Kadir</span>, um mundo onde as lendas ganham vida...
         </p>
+        <div className="mb-4 space-x-4">
+          <label>
+            <input
+              type="radio"
+              name="gender"
+              value="male"
+              checked={gender === 'male'}
+              onChange={() => setGender('male')}
+            />
+            <span className="ml-1">Masculino</span>
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="gender"
+              value="female"
+              checked={gender === 'female'}
+              onChange={() => setGender('female')}
+            />
+            <span className="ml-1">Feminino</span>
+          </label>
+        </div>
         <div className="mt-2">
-          <button className="button" onClick={handleProceed}>
+          <button className="button" onClick={handleProceed} disabled={!gender}>
             Próximo
           </button>
         </div>

--- a/frontend/src/components/QuestionnairePage.jsx
+++ b/frontend/src/components/QuestionnairePage.jsx
@@ -6,16 +6,17 @@ export default function QuestionnairePage() {
   const navigate = useNavigate()
   const { state } = useLocation()
   const name = state?.name
+  const gender = state?.gender
 
   useEffect(() => {
-    if (!name) navigate('/intro')
-  }, [name, navigate])
+    if (!name || !gender) navigate('/intro')
+  }, [name, gender, navigate])
 
   const handleComplete = (stats) => {
-    navigate('/element', { state: { name, stats } })
+    navigate('/element', { state: { name, gender, stats } })
   }
 
-  if (!name) return null
+  if (!name || !gender) return null
 
   return (
     <div className="flex items-center justify-center h-full">


### PR DESCRIPTION
## Summary
- prompt player for gender in IntroPage
- persist gender through QuestionnairePage and ElementPage
- include gender when saving pet data

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873f263f214832a972cf1a9cb8229d0