### PR TITLE
Adjust skins per gender

### DIFF
--- a/Assets/Character/character_metadata_final.json
+++ b/Assets/Character/character_metadata_final.json
@@ -1,12 +1,16 @@
 {
-  "skins": [
-    "Assets/Character/body/female/dark.png",
-    "Assets/Character/body/female/light.png",
-    "Assets/Character/body/female/tanned.png",
-    "Assets/Character/body/male/dark.png",
-    "Assets/Character/body/male/light.png",
-    "Assets/Character/body/male/tanned.png"
-  ],
+  "skins": {
+    "male": [
+      "Assets/Character/body/male/dark.png",
+      "Assets/Character/body/male/light.png",
+      "Assets/Character/body/male/tanned.png"
+    ],
+    "female": [
+      "Assets/Character/body/female/dark.png",
+      "Assets/Character/body/female/light.png",
+      "Assets/Character/body/female/tanned.png"
+    ]
+  },
   "sexes": [
     "male",
     "female"

--- a/src/components/CharacterCreation.tsx
+++ b/src/components/CharacterCreation.tsx
@@ -104,7 +104,16 @@ export default function CharacterCreation() {
   }, [selection])
 
   const handle = (field: keyof CharacterSelection, value: any) => {
-    setSelection(prev => ({ ...prev, [field]: value }))
+    setSelection(prev => {
+      if (field === 'sex') {
+        return {
+          ...prev,
+          sex: value as 'male' | 'female',
+          skin: `Assets/Character/body/${value}/light.png`,
+        }
+      }
+      return { ...prev, [field]: value }
+    })
   }
 
   const handleHair = (field: 'style' | 'color', value: string) => {
@@ -119,7 +128,7 @@ export default function CharacterCreation() {
     if (!metadata) return []
     switch (key) {
       case 'skin':
-        return metadata.skins.filter((p: string) => p.includes(selection.sex))
+        return metadata.skins[selection.sex] ?? []
       case 'eyes':
         return metadata.eyes.filter((p: string) => p.includes(selection.sex))
       case 'hairStyle':


### PR DESCRIPTION
## Summary
- group character body textures by gender in metadata
- change selection logic to update skin when sex changes
- read skins for the current sex from metadata

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873f99c3074832a8d5975fe97ad5e59