### PR TITLE
Disallow empty skin option

### DIFF
--- a/src/components/CharacterCreation.tsx
+++ b/src/components/CharacterCreation.tsx
@@ -174,6 +174,7 @@ export default function CharacterCreation() {
           options={list('skin')}
           value={selection.skin}
           onChange={v => handle('skin', v)}
+          allowNone={false}
         />
         <OptionRow
           label='Olhos'


### PR DESCRIPTION
## Summary
- ensure CharacterCreation always selects a skin by disallowing the none option

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873fd8f4c6c832aa6c8ab4d7a2e2877