### PR TITLE
Set minimum window size

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -48,6 +48,10 @@ async function createWindow() {
   win = new BrowserWindow({
     title: 'Main window',
     icon: path.join(process.env.VITE_PUBLIC, 'favicon.ico'),
+    width: 1536,
+    height: 1024,
+    resizable: false,
+    maximizable: true,
     webPreferences: {
       preload,
       // Warning: Enable nodeIntegration and disable contextIsolation is not secure in production


### PR DESCRIPTION
## Summary
- configure Electron window to open with size 1536x1024
- disable resizing so window can only be minimized, maximized or closed

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68740dcebb84832a818a5b411f17c282