### PR TITLE
Adjust first logo timing

### DIFF
--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -79,7 +79,7 @@ const StartScreen = () => {
   }, [prefs.fullscreen])
 
   useEffect(() => {
-    const beforeTimer = setTimeout(() => setShowLogoBefore(true), 2000)
+    const beforeTimer = setTimeout(() => setShowLogoBefore(true), 3000)
     const afterTimer = setTimeout(() => {
       setShowLogoBefore(false)
       setShowLogoAfter(true)


### PR DESCRIPTION
## Summary
- tweak the StartScreen timer so the first logo appears after 3 seconds

## Testing
- `npm test` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687410575204832aaa827fa29acc412d