### PR TITLE
Implementa validações e transições na criação de personagem

### DIFF
--- a/src/components/CharacterCreation.css
+++ b/src/components/CharacterCreation.css
@@ -91,3 +91,39 @@
   margin-top: 12px;
   padding: 6px 12px;
 }
+
+/* Wrapper to control fade transitions */
+.character-creation-wrapper {
+  position: relative;
+  transition: opacity 0.5s ease;
+}
+
+.character-creation.fade-out {
+  opacity: 0;
+  transition: opacity 0.5s ease;
+}
+
+.next-screen {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background: #000;
+  color: #fff;
+  opacity: 0;
+  transition: opacity 0.5s ease;
+  gap: 20px;
+}
+
+.next-screen.visible {
+  opacity: 1;
+}
+
+.error-message {
+  color: red;
+  height: 18px;
+  margin-top: 4px;
+}


### PR DESCRIPTION
## Resumo
- valida o nome do personagem permitindo somente letras, números, ponto e underline e limitando a 15 caracteres
- exibe mensagem de erro quando o nome é inválido
- altera o botão de confirmação para "Prosseguir"
- ao prosseguir, aplica fade-out na tela atual e fade-in em uma nova tela com texto introdutório

## Testes
- `npm test` *(falha: vite não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6874163efa78832aa7a83de86f1a69c0