### PR TITLE
Improve intro screen text presentation

### DIFF
--- a/src/components/CharacterCreation.css
+++ b/src/components/CharacterCreation.css
@@ -122,6 +122,32 @@
   opacity: 1;
 }
 
+.next-text {
+  opacity: 0;
+  max-width: 600px;
+  width: 80%;
+  transition: opacity 1s ease;
+}
+
+.next-text.visible {
+  opacity: 1;
+}
+
+.proceed-btn {
+  margin-top: 20px;
+  padding: 0.6em 1.2em;
+  background: #1a1a1a;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  opacity: 0;
+  transition: opacity 1s ease;
+}
+
+.proceed-btn.visible {
+  opacity: 1;
+}
+
 .error-message {
   color: red;
   height: 18px;

--- a/src/components/CharacterCreation.tsx
+++ b/src/components/CharacterCreation.tsx
@@ -80,6 +80,8 @@ export default function CharacterCreation() {
   const [errorMsg, setErrorMsg] = useState('')
   const [phase, setPhase] = useState<'create' | 'intro'>('create')
   const [fade, setFade] = useState<'in' | 'out'>('in')
+  const [showIntroText, setShowIntroText] = useState(false)
+  const [showProceed, setShowProceed] = useState(false)
 
   useEffect(() => {
     fetch('Assets/Character/character_metadata_final.json')
@@ -221,6 +223,20 @@ export default function CharacterCreation() {
     }, 500)
   }
 
+  useEffect(() => {
+    if (phase === 'intro') {
+      const textTimer = setTimeout(() => setShowIntroText(true), 500)
+      const btnTimer = setTimeout(() => setShowProceed(true), 1500)
+      return () => {
+        clearTimeout(textTimer)
+        clearTimeout(btnTimer)
+      }
+    } else {
+      setShowIntroText(false)
+      setShowProceed(false)
+    }
+  }, [phase])
+
   const list = (key: string) => {
     if (!metadata) return []
     switch (key) {
@@ -353,10 +369,12 @@ export default function CharacterCreation() {
       )}
       {phase === 'intro' && (
         <div className={`next-screen ${fade === 'in' ? 'visible' : ''}`}>
-          <p>
+          <p className={`next-text ${showIntroText ? 'visible' : ''}`}>
             Como toda grande jornada, um companheiro leal é essencial. Mas antes, preciso entender quem você é, para encontrar aquele que mais combina com você.
           </p>
-          <button className='proceed-btn'>Prosseguir</button>
+          {showProceed && (
+            <button className={`proceed-btn ${showProceed ? 'visible' : ''}`}>Prosseguir</button>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- widen and fade in the intro message after character creation
- fade in the proceed button after the text

## Testing
- `npm test` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68741e2cb540832a838f6e6b49133c8f