### PR TITLE
Update UI styles

### DIFF
--- a/src/components/CharacterCreation.css
+++ b/src/components/CharacterCreation.css
@@ -124,8 +124,8 @@
 
 .next-text {
   opacity: 0;
-  max-width: 600px;
-  width: 80%;
+  max-width: 800px;
+  width: 90%;
   transition: opacity 1s ease;
 }
 
@@ -170,6 +170,12 @@
   transition: opacity 0.5s ease;
 }
 
+.quiz-screen p,
+.element-screen p {
+  max-width: 800px;
+  width: 90%;
+}
+
 .quiz-screen.fade-out,
 .element-screen.fade-out {
   opacity: 0;
@@ -177,19 +183,24 @@
 
 .options {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  flex-wrap: wrap;
   gap: 10px;
+  justify-content: center;
 }
 
 .element-options {
   display: flex;
   gap: 20px;
+  justify-content: center;
+  flex-wrap: wrap;
 }
 
 .element-option {
   display: flex;
   flex-direction: column;
   align-items: center;
+  transition: transform 0.3s, box-shadow 0.3s;
 }
 
 .element-option img {
@@ -198,6 +209,17 @@
   transition: transform 0.3s;
 }
 
+.element-option:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 15px rgba(255, 255, 255, 0.3);
+}
+
 .element-option img:hover {
   transform: scale(1.1);
+}
+
+.element-option span {
+  margin-top: 4px;
+  width: 90px;
+  text-align: center;
 }

--- a/src/components/StartScreen.css
+++ b/src/components/StartScreen.css
@@ -117,6 +117,9 @@
 .intro-text {
   opacity: 0;
   transition: opacity 1s ease;
+  max-width: 800px;
+  width: 90%;
+  text-align: center;
 }
 
 .intro-text.visible {
@@ -126,9 +129,7 @@
 .proceed-btn {
   margin-top: 20px;
   padding: 0.6em 1.2em;
-  background: #1a1a1a;
-  color: #fff;
-  border: none;
+  border: 1px solid transparent;
   border-radius: 8px;
 }
 


### PR DESCRIPTION
## Summary
- unify the intro "Prosseguir" button appearance with the character creation screen
- widen intro text and quiz/dialog areas for better readability
- arrange quiz options side by side
- add floating hover effect when selecting an element

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687424e3c694832ab1defceca4598bb4