### PR TITLE
Fix proceed button display in intro

### DIFF
--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -123,7 +123,12 @@ const StartScreen = () => {
             <p key={i} className={`intro-text ${messageIndex > i ? 'visible' : ''}`}>{m}</p>
           ))}
           {messageIndex >= messages.length && (
-            <button className='proceed-btn' onClick={() => setPhase('create')}>Prosseguir</button>
+            <button
+              className='proceed-btn visible'
+              onClick={() => setPhase('create')}
+            >
+              Prosseguir
+            </button>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
- ensure proceed button on intro screen is visible by default

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68742832531c832a8c2d1aa28cd724a4