### PR TITLE
Update quiz and element styling

### DIFF
--- a/src/components/CharacterCreation.css
+++ b/src/components/CharacterCreation.css
@@ -125,7 +125,7 @@
 .next-text {
   opacity: 0;
   max-width: 800px;
-  width: 90%;
+  min-width: 500px;
   transition: opacity 1s ease;
 }
 
@@ -170,9 +170,13 @@
   transition: opacity 0.5s ease;
 }
 
-.quiz-screen p,
+.quiz-screen p {
+  width: 500px;
+}
+
 .element-screen p {
   max-width: 800px;
+  min-width: 500px;
   width: 90%;
 }
 
@@ -184,7 +188,7 @@
 .options {
   display: flex;
   flex-direction: row;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 10px;
   justify-content: center;
 }
@@ -193,7 +197,7 @@
   display: flex;
   gap: 20px;
   justify-content: center;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 
 .element-option {
@@ -210,7 +214,7 @@
 }
 
 .element-option:hover {
-  transform: translateY(-5px);
+  animation: float 1s ease-in-out infinite;
   box-shadow: 0 8px 15px rgba(255, 255, 255, 0.3);
 }
 
@@ -222,4 +226,13 @@
   margin-top: 4px;
   width: 90px;
   text-align: center;
+}
+
+@keyframes float {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-5px);
+  }
 }


### PR DESCRIPTION
## Summary
- adjust width for quiz questions and element screen text
- display quiz options and element choices in one row
- apply floating animation on element selection hover

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68742b34fcd0832aba034b4c6d5e086e