### PR TITLE
Add fade intro effect

### DIFF
--- a/src/components/StartScreen.css
+++ b/src/components/StartScreen.css
@@ -112,14 +112,21 @@
   align-items: center;
   justify-content: center;
   gap: 10px;
+  opacity: 0;
+  transition: opacity 2s ease;
+}
+
+.intro-screen.visible {
+  opacity: 1;
 }
 
 .intro-text {
   opacity: 0;
-  transition: opacity 1s ease;
+  transition: opacity 2s ease;
   max-width: 800px;
   width: 90%;
   text-align: center;
+  font-size: 20px;
 }
 
 .intro-text.visible {
@@ -143,7 +150,7 @@
   justify-content: center;
   opacity: 0;
   transform: translateY(20px);
-  transition: opacity 0.5s ease, transform 0.5s ease;
+  transition: opacity 2s ease, transform 2s ease;
   pointer-events: none;
 }
 

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -19,6 +19,7 @@ const StartScreen = () => {
   const lastVolumeRef = useRef(prefs.volume)
 
   const [phase, setPhase] = useState<'menu' | 'intro' | 'create'>('menu')
+  const [showIntro, setShowIntro] = useState(false)
   const [messageIndex, setMessageIndex] = useState(0)
   const messages = [
     'Boas vindas, viajante...',
@@ -86,10 +87,18 @@ const StartScreen = () => {
     }, 4000)
 
     return () => {
-      clearTimeout(beforeTimer)
-      clearTimeout(afterTimer)
-    }
+    clearTimeout(beforeTimer)
+    clearTimeout(afterTimer)
+  }
   }, [])
+
+  useEffect(() => {
+    if (phase === 'intro') {
+      const timer = setTimeout(() => setShowIntro(true), 10)
+      return () => clearTimeout(timer)
+    }
+    setShowIntro(false)
+  }, [phase])
 
   return (
     <div className='start-screen'>
@@ -118,7 +127,7 @@ const StartScreen = () => {
         </div>
       )}
       {phase === 'intro' && (
-        <div className='intro-screen'>
+        <div className={`intro-screen ${showIntro ? 'visible' : ''}`}>
           {messages.map((m, i) => (
             <p key={i} className={`intro-text ${messageIndex > i ? 'visible' : ''}`}>{m}</p>
           ))}


### PR DESCRIPTION
## Summary
- animate showing the intro screen before character creation
- tweak transition durations for a slower fade
- enlarge intro text

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687433b83bf8832aaf3cd80c4cecb80c