### PR TITLE
Add custom cursor with hold effect

### DIFF
--- a/frontend/src/components/CustomCursor.jsx
+++ b/frontend/src/components/CustomCursor.jsx
@@ -1,32 +1,57 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
+import arrowImg from '../../../Assets/Cursors/cursor.png'
+import pointerImg from '../../../Assets/Cursors/pointer.png'
 import grabImg from '../../../Assets/Cursors/grab.png'
-import cursorImg from '../../../Assets/Cursors/pointer.png'
+import leaveImg from '../../../Assets/Cursors/leave.png'
 
 export default function CustomCursor() {
   const [coords, setCoords] = useState({ x: 0, y: 0 })
-  const [imgSrc, setImgSrc] = useState(cursorImg)
+  const [imgSrc, setImgSrc] = useState(arrowImg)
+  const [isPressed, setIsPressed] = useState(false)
+  const lastCoords = useRef({ x: 0, y: 0 })
 
   useEffect(() => {
-    const handleMove = (e) => {
-      setCoords({ x: e.clientX, y: e.clientY })
-      const el = document.elementFromPoint(e.clientX, e.clientY)
+    const updateImgFromElement = (x, y) => {
+      const el = document.elementFromPoint(x, y)
       if (el) {
         const cursorStyle = window.getComputedStyle(el).cursor
-        if (cursorStyle.includes('grab')) {
-          setImgSrc(grabImg)
-        } else if (cursorStyle.includes('pointer')) {
-          setImgSrc(cursorImg)
+        if (cursorStyle.includes('pointer')) {
+          setImgSrc(pointerImg)
         } else {
-          setImgSrc(cursorImg)
+          setImgSrc(arrowImg)
         }
       } else {
-        setImgSrc(cursorImg)
+        setImgSrc(arrowImg)
       }
     }
 
+    const handleMove = (e) => {
+      setCoords({ x: e.clientX, y: e.clientY })
+      lastCoords.current = { x: e.clientX, y: e.clientY }
+      if (!isPressed) updateImgFromElement(e.clientX, e.clientY)
+    }
+
+    const handleDown = () => {
+      setIsPressed(true)
+      setImgSrc(grabImg)
+    }
+
+    const handleUp = () => {
+      setIsPressed(false)
+      setImgSrc(leaveImg)
+      const { x, y } = lastCoords.current
+      setTimeout(() => updateImgFromElement(x, y), 100)
+    }
+
     window.addEventListener('mousemove', handleMove)
-    return () => window.removeEventListener('mousemove', handleMove)
-  }, [])
+    window.addEventListener('mousedown', handleDown)
+    window.addEventListener('mouseup', handleUp)
+    return () => {
+      window.removeEventListener('mousemove', handleMove)
+      window.removeEventListener('mousedown', handleDown)
+      window.removeEventListener('mouseup', handleUp)
+    }
+  }, [isPressed])
 
   return (
     <img
@@ -36,7 +61,8 @@ export default function CustomCursor() {
         position: 'fixed',
         top: coords.y,
         left: coords.x,
-        transform: 'translate(-50%, -50%)',
+        transform: `translate(-50%, -50%) scale(${isPressed ? 1.1 : 1})`,
+        transition: 'transform 0.1s ease',
         pointerEvents: 'none',
         zIndex: 9999,
       }}


### PR DESCRIPTION
## Summary
- hide the system cursor (already done in global CSS) and use images for a fake cursor
- switch cursor images between pointer and arrow depending on hovered element
- show grab and leave images when clicking and releasing
- scale cursor up while mouse button is held

## Testing
- `npm run lint --prefix frontend` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874365d586c832abf5632bb442a6448