### PR TITLE
Fix button positioning and quiz transitions

### DIFF
--- a/src/components/CharacterCreation.css
+++ b/src/components/CharacterCreation.css
@@ -149,6 +149,14 @@
   opacity: 1;
 }
 
+.next-screen .proceed-btn {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 0;
+}
+
 .error-message {
   color: red;
   height: 18px;
@@ -190,15 +198,16 @@
 
 .options {
   display: flex;
-  flex-direction: column;
-  flex-wrap: nowrap;
+  flex-direction: row;
   gap: 10px;
   justify-content: center;
   align-items: center;
+  width: 600px;
 }
 
 .options button {
-  width: 600px;
+  flex: 1;
+  width: auto;
 }
 
 .element-options {

--- a/src/components/CharacterCreation.tsx
+++ b/src/components/CharacterCreation.tsx
@@ -428,11 +428,15 @@ export default function CharacterCreation() {
       life: prev.life + opt.effects.life,
     }))
     if (questionIndex + 1 < questions.length) {
-      setQuestionIndex(i => i + 1)
-    } else {
-      setAttributes(prev => ({ ...prev, life: prev.life * 10 }))
       setFade('out')
       setTimeout(() => {
+        setQuestionIndex(i => i + 1)
+        setFade('in')
+      }, 500)
+    } else {
+      setFade('out')
+      setTimeout(() => {
+        setAttributes(prev => ({ ...prev, life: prev.life * 10 }))
         setPhase('element')
         setFade('in')
       }, 500)

--- a/src/components/StartScreen.css
+++ b/src/components/StartScreen.css
@@ -140,6 +140,14 @@
   border-radius: 8px;
 }
 
+.intro-screen .proceed-btn {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 0;
+}
+
 .creator-container {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Summary
- keep intro text centered by absolutely positioning the proceed button
- fix proceed button positioning on the creation intro screen
- lay out quiz options so all buttons fit inside a 600px row
- fade between quiz questions for a smoother experience

## Testing
- `npm test` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68743bfc6f30832a96785a67dcea0218