### PR TITLE
Hide menu bar & center close button

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -46,12 +46,13 @@ const indexHtml = path.join(RENDERER_DIST, 'index.html')
 
 async function createWindow() {
   win = new BrowserWindow({
-    title: 'Main window',
+    title: 'Kadir11',
     icon: path.join(process.env.VITE_PUBLIC, 'favicon.ico'),
     width: 1536,
     height: 1024,
     resizable: false,
     maximizable: true,
+    autoHideMenuBar: true,
     webPreferences: {
       preload,
       // Warning: Enable nodeIntegration and disable contextIsolation is not secure in production
@@ -62,6 +63,9 @@ async function createWindow() {
       // contextIsolation: false,
     },
   })
+
+  // Ensure the default menu bar is hidden
+  win.setMenuBarVisibility(false)
 
   if (VITE_DEV_SERVER_URL) { // #298
     win.loadURL(VITE_DEV_SERVER_URL)

--- a/src/components/OptionsModal.css
+++ b/src/components/OptionsModal.css
@@ -32,7 +32,7 @@
 }
 
 .options-footer {
-  text-align: right;
+  text-align: center;
 }
 
 .mute-btn {


### PR DESCRIPTION
## Summary
- center close button in options modal
- hide default menu bar and rename app title

## Testing
- `npm run test` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68743d81faa8832ab3fe36556dfeb9dc