### PR TITLE
Fix UI spacing and quiz layout

### DIFF
--- a/src/components/CharacterCreation.css
+++ b/src/components/CharacterCreation.css
@@ -151,7 +151,7 @@
 
 .next-screen .proceed-btn {
   position: absolute;
-  bottom: 40px;
+  top: 140px;
   left: 50%;
   transform: translateX(-50%);
   margin-top: 0;
@@ -197,17 +197,15 @@
 }
 
 .options {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: 10px;
-  justify-content: center;
-  align-items: center;
   width: 600px;
 }
 
 .options button {
-  flex: 1;
-  width: auto;
+  width: 100%;
+  height: 70px;
 }
 
 .element-options {

--- a/src/components/CharacterCreation.tsx
+++ b/src/components/CharacterCreation.tsx
@@ -549,7 +549,6 @@ export default function CharacterCreation() {
           <input value={selection.name} onChange={e => handleNameChange(e.target.value)} />
             </label>
             <div className='error-message'>{errorMsg}</div>
-            <div className='nickname'>{selection.name}</div>
             <button className='confirm' onClick={confirm}>Prosseguir</button>
           </div>
           <div className='fields-right'>

--- a/src/components/StartScreen.css
+++ b/src/components/StartScreen.css
@@ -142,7 +142,7 @@
 
 .intro-screen .proceed-btn {
   position: absolute;
-  bottom: 40px;
+  bottom: 250px;
   left: 50%;
   transform: translateX(-50%);
   margin-top: 0;


### PR DESCRIPTION
## Summary
- raise intro proceed button on StartScreen
- move proceed button on companion intro screen
- tweak quiz option layout
- remove duplicate name display

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68743ff7351c832a80278ea33171e96b