### PR TITLE
Fix pet asset path and show evolution animation

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -144,7 +144,12 @@ ipcMain.handle('save-character', (_event, data) => {
 
 ipcMain.handle('get-pet-assets', (_event, especie: string, elemento: string) => {
   const base = path.join(process.env.APP_ROOT, 'Assets', 'Mons')
-  const specieDir = path.join(base, especie)
+  const sanitize = (name: string) =>
+    name
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/\s+/g, '')
+  const specieDir = path.join(base, sanitize(especie))
 
   const pickPetDir = (dir: string): string | undefined => {
     if (!fs.existsSync(dir)) return undefined

--- a/src/components/CharacterCreation.css
+++ b/src/components/CharacterCreation.css
@@ -276,6 +276,24 @@
   image-rendering: pixelated;
 }
 
+.pet-screen video {
+  width: 128px;
+  height: 128px;
+}
+
+.pet-image.jump {
+  animation: jump 0.5s ease;
+}
+
+@keyframes jump {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-20px);
+  }
+}
+
 .pet-name-input {
   padding: 4px;
   background-color: #1a1a1a;

--- a/src/components/CharacterCreation.tsx
+++ b/src/components/CharacterCreation.tsx
@@ -260,7 +260,7 @@ export default function CharacterCreation() {
   const [frameRow, setFrameRow] = useState(frontRow)
   const [orientation, setOrientation] = useState(0)
   const [errorMsg, setErrorMsg] = useState('')
-  const [phase, setPhase] = useState<'create' | 'intro' | 'quiz' | 'element' | 'pet'>('create')
+  const [phase, setPhase] = useState<'create' | 'intro' | 'quiz' | 'element' | 'evolution' | 'pet'>('create')
   const [fade, setFade] = useState<'in' | 'out'>('in')
   const [showIntroText, setShowIntroText] = useState(false)
   const [showProceed, setShowProceed] = useState(false)
@@ -270,6 +270,7 @@ export default function CharacterCreation() {
   const [petInfo, setPetInfo] = useState<Awaited<ReturnType<typeof determinarPetFinal>> | null>(null)
   const [showNameInput, setShowNameInput] = useState(false)
   const [petName, setPetName] = useState('')
+  const [petJump, setPetJump] = useState(false)
 
   useEffect(() => {
     fetch('Assets/Character/character_metadata_final.json')
@@ -452,7 +453,7 @@ export default function CharacterCreation() {
     setPetInfo(pet)
     setFade('out')
     setTimeout(() => {
-      setPhase('pet')
+      setPhase('evolution')
       setFade('in')
     }, 500)
   }
@@ -506,6 +507,16 @@ export default function CharacterCreation() {
   const listSex = (key: string) => {
     if (!metadata) return []
     return metadata.clothes[key]?.[selection.sex] ?? []
+  }
+
+  const finishEvolution = () => {
+    setFade('out')
+    setTimeout(() => {
+      setPhase('pet')
+      setFade('in')
+      setPetJump(true)
+      setTimeout(() => setPetJump(false), 500)
+    }, 500)
   }
 
   return (
@@ -646,9 +657,29 @@ export default function CharacterCreation() {
           </div>
         </div>
       )}
+      {phase === 'evolution' && petInfo && (
+        <div className={`pet-screen ${fade === 'in' ? 'visible' : ''}`}>
+          {petInfo.animacaoEvolucao.endsWith('.mp4') ? (
+            <video
+              src={petInfo.animacaoEvolucao}
+              autoPlay
+              onEnded={finishEvolution}
+            />
+          ) : (
+            <img
+              src={petInfo.animacaoEvolucao}
+              onLoad={() => setTimeout(finishEvolution, 3000)}
+            />
+          )}
+        </div>
+      )}
       {phase === 'pet' && petInfo && (
         <div className={`pet-screen ${fade === 'in' ? 'visible' : ''}`}>
-          <img src={petInfo.assetPet} alt={petInfo.especie} />
+          <img
+            src={petInfo.assetPet}
+            alt={petInfo.especie}
+            className={`pet-image ${petJump ? 'jump' : ''}`}
+          />
           <p>Parabéns você adquiriu um {petInfo.especie}!</p>
           {!showNameInput ? (
             <button onClick={() => setShowNameInput(true)}>Deseja dar um nome a ele?</button>


### PR DESCRIPTION
## Summary
- ensure pet assets resolve correctly by sanitizing species names
- show evolution animation before pet appears
- add jump animation to pet when revealed

## Testing
- `npm test` *(fails: vite not found / dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876ed8606b8832aa46b78ba586a3eae