### PR TITLE
Adjust evolution animation size and fade

### DIFF
--- a/src/components/CharacterCreation.css
+++ b/src/components/CharacterCreation.css
@@ -251,6 +251,7 @@
   }
 }
 
+
 .pet-screen {
   position: absolute;
   inset: 0;
@@ -262,8 +263,12 @@
   justify-content: center;
   text-align: center;
   gap: 20px;
-  opacity: 1;
+  opacity: 0;
   transition: opacity 0.5s ease;
+}
+
+.pet-screen.visible {
+  opacity: 1;
 }
 
 .pet-screen.fade-out {
@@ -277,8 +282,8 @@
 }
 
 .pet-screen video {
-  width: 128px;
-  height: 128px;
+  width: 500px;
+  height: 500px;
 }
 
 .pet-image.jump {

--- a/src/components/CharacterCreation.tsx
+++ b/src/components/CharacterCreation.tsx
@@ -658,7 +658,7 @@ export default function CharacterCreation() {
         </div>
       )}
       {phase === 'evolution' && petInfo && (
-        <div className={`pet-screen ${fade === 'in' ? 'visible' : ''}`}>
+        <div className={`pet-screen ${fade === 'in' ? 'visible' : 'fade-out'}`}>
           {petInfo.animacaoEvolucao.endsWith('.mp4') ? (
             <video
               src={petInfo.animacaoEvolucao}
@@ -674,7 +674,7 @@ export default function CharacterCreation() {
         </div>
       )}
       {phase === 'pet' && petInfo && (
-        <div className={`pet-screen ${fade === 'in' ? 'visible' : ''}`}>
+        <div className={`pet-screen ${fade === 'in' ? 'visible' : 'fade-out'}`}>
           <img
             src={petInfo.assetPet}
             alt={petInfo.especie}


### PR DESCRIPTION
## Summary
- make the pet evolution screen fade in/out
- enlarge evolution video to 500px

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876f1a70394832a81be317b7aec731c