### PR TITLE
Add width rule to pet display wrapper

### DIFF
--- a/frontend/src/components/HatchPage.jsx
+++ b/frontend/src/components/HatchPage.jsx
@@ -18,7 +18,7 @@ export default function HatchPage() {
   }, [navigate])
 
   return (
-    <div className="flex items-center justify-center h-full">
+    <div className="character-creation-wrapper flex items-center justify-center h-full">
       {!showPet ? (
         <img src={evolution} alt="Hatching" className="w-64 h-64" />
       ) : (

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -250,3 +250,7 @@ img {
     justify-content: center;
     width: 500px;
 }
+
+.character-creation-wrapper {
+    width: 100%;
+}


### PR DESCRIPTION
## Summary
- ensure hatch page wrapper uses `character-creation-wrapper`
- make `.character-creation-wrapper` span the full width

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_687797fbf3cc832a9730c5a9dbcd4d0f