### PR TITLE
Render player and pet on new map screen

### DIFF
--- a/src/components/CharacterCreation.css
+++ b/src/components/CharacterCreation.css
@@ -306,3 +306,12 @@
   border: 1px solid #555;
   border-radius: 4px;
 }
+
+.start-map-btn {
+  margin-top: 8px;
+  padding: 6px 12px;
+  border-radius: 6px;
+  background-color: #1a1a1a;
+  color: #fff;
+  border: none;
+}

--- a/src/components/CharacterCreation.tsx
+++ b/src/components/CharacterCreation.tsx
@@ -253,7 +253,16 @@ function OptionRow({ label, options, value, onChange, allowNone = true }: Option
   )
 }
 
-export default function CharacterCreation() {
+export interface CharacterCreationResult {
+  playerImage: string
+  petImage: string
+}
+
+export default function CharacterCreation({
+  onComplete,
+}: {
+  onComplete?: (result: CharacterCreationResult) => void
+}) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [metadata, setMetadata] = useState<any>(null)
   const [selection, setSelection] = useState<CharacterSelection>(defaultSelection)
@@ -682,7 +691,9 @@ export default function CharacterCreation() {
           />
           <p>Parabéns você adquiriu um {petInfo.especie}!</p>
           {!showNameInput ? (
-            <button onClick={() => setShowNameInput(true)}>Deseja dar um nome a ele?</button>
+            <button onClick={() => setShowNameInput(true)}>
+              Deseja dar um nome a ele?
+            </button>
           ) : (
             <input
               className='pet-name-input'
@@ -691,6 +702,17 @@ export default function CharacterCreation() {
               placeholder='Digite o nome'
             />
           )}
+          <button
+            className='start-map-btn'
+            onClick={() => {
+              const canvas = canvasRef.current
+              if (!canvas || !petInfo) return
+              const playerImage = canvas.toDataURL()
+              onComplete?.({ playerImage, petImage: petInfo.assetPet })
+            }}
+          >
+            Começar aventura
+          </button>
         </div>
       )}
     </div>

--- a/src/components/GameMap.tsx
+++ b/src/components/GameMap.tsx
@@ -43,7 +43,12 @@ const loadImage = (src: string) =>
     img.onload = () => resolve(img)
   })
 
-const GameMap = () => {
+interface Props {
+  playerSrc: string
+  petSrc: string
+}
+
+const GameMap = ({ playerSrc, petSrc }: Props) => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const collisionPolygons = useRef<Point[][]>([])
   const playerPos = useRef<Point>({ x: 0, y: 0 })
@@ -85,6 +90,9 @@ const GameMap = () => {
           loadImage(new URL(`../../tileset/${ts.image}`, import.meta.url).href)
         )
       )
+
+      const playerImg = await loadImage(playerSrc)
+      const petImg = await loadImage(petSrc)
 
 
       const drawLayer = (layer: TileLayer) => {
@@ -233,10 +241,20 @@ const GameMap = () => {
         map.layers.forEach(layer => {
           if (layer.type === 'tilelayer') drawLayer(layer as TileLayer)
         })
-        ctx.fillStyle = 'blue'
-        ctx.fillRect(petPos.current.x, petPos.current.y, map.tilewidth, map.tileheight)
-        ctx.fillStyle = 'red'
-        ctx.fillRect(playerPos.current.x, playerPos.current.y, map.tilewidth, map.tileheight)
+        ctx.drawImage(
+          petImg,
+          petPos.current.x,
+          petPos.current.y,
+          map.tilewidth,
+          map.tileheight
+        )
+        ctx.drawImage(
+          playerImg,
+          playerPos.current.x,
+          playerPos.current.y,
+          map.tilewidth,
+          map.tileheight
+        )
       }
 
       const movePlayer = (key: string) => {
@@ -303,7 +321,7 @@ const GameMap = () => {
     return () => {
       if (cleanup) cleanup()
     }
-  }, [])
+  }, [playerSrc, petSrc])
 
   return <canvas ref={canvasRef} style={{ imageRendering: 'pixelated' }} />
 }

--- a/src/components/StartScreen.css
+++ b/src/components/StartScreen.css
@@ -167,3 +167,17 @@
   transform: translateY(0);
   pointer-events: auto;
 }
+
+.game-container {
+  position: fixed;
+  inset: 0;
+  background: #000;
+  opacity: 0;
+  transition: opacity 2s ease;
+  pointer-events: none;
+}
+
+.game-container.visible {
+  opacity: 1;
+  pointer-events: auto;
+}

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import OptionsModal, { Preferences } from './OptionsModal'
-import CharacterCreation from './CharacterCreation'
+import CharacterCreation, { CharacterCreationResult } from './CharacterCreation'
+import GameMap from './GameMap'
 import { t } from '@/locales'
 import './StartScreen.css'
 
@@ -18,7 +19,9 @@ const StartScreen = () => {
   })
   const lastVolumeRef = useRef(prefs.volume)
 
-  const [phase, setPhase] = useState<'menu' | 'intro' | 'create'>('menu')
+  const [phase, setPhase] = useState<'menu' | 'intro' | 'create' | 'game'>('menu')
+  const [playerImage, setPlayerImage] = useState<string | null>(null)
+  const [petImage, setPetImage] = useState<string | null>(null)
   const [showIntro, setShowIntro] = useState(false)
   const [introVisible, setIntroVisible] = useState(false)
   const [showProceed, setShowProceed] = useState(false)
@@ -154,8 +157,21 @@ const StartScreen = () => {
           )}
         </div>
       )}
-      <div className={`creator-container ${phase === 'create' ? 'visible' : ''}`}> 
-        {phase === 'create' && <CharacterCreation />}
+      <div className={`creator-container ${phase === 'create' ? 'visible' : ''}`}>
+        {phase === 'create' && (
+          <CharacterCreation
+            onComplete={({ playerImage, petImage }: CharacterCreationResult) => {
+              setPlayerImage(playerImage)
+              setPetImage(petImage)
+              setPhase('game')
+            }}
+          />
+        )}
+      </div>
+      <div className={`game-container ${phase === 'game' ? 'visible' : ''}`}>
+        {phase === 'game' && playerImage && petImage && (
+          <GameMap playerSrc={playerImage} petSrc={petImage} />
+        )}
       </div>
       {showExitConfirm && (
         <div className='exit-dropdown'>


### PR DESCRIPTION
## Summary
- accept a callback in `CharacterCreation` to return the final player and pet images
- load those images in `GameMap` and draw them over the Tiled map
- transition from the start screen to the map once creation is done
- basic styles for the new game container and start button

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d96701a68832aabd085dbf1b386c6