### PR TITLE
Implement camera follow for game map

### DIFF
--- a/src/components/GameMap.css
+++ b/src/components/GameMap.css
@@ -1,0 +1,7 @@
+.game-map-wrapper {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+.game-map-wrapper canvas { image-rendering: pixelated; position: absolute; left: 0; top: 0; }


### PR DESCRIPTION
## Summary
- show player and pet when starting the adventure
- add a camera system so the canvas centers on the player

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687da44e57e4832aa62c1c9c352d6f97