### PR TITLE
Add map screen after pet creation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import IntroPage from './components/IntroPage'
 import QuestionnairePage from './components/QuestionnairePage'
 import ElementPage from './components/ElementPage'
 import HatchPage from './components/HatchPage'
+import MapPage from './components/MapPage'
 import TitleBar from './components/TitleBar'
 import CustomCursor from './components/CustomCursor'
 
@@ -19,6 +20,7 @@ export default function App() {
         <Route path="/questions" element={<QuestionnairePage />} />
         <Route path="/element" element={<ElementPage />} />
         <Route path="/hatch" element={<HatchPage />} />
+        <Route path="/map" element={<MapPage />} />
       </Routes>
     </>
   )

--- a/frontend/src/components/HatchPage.jsx
+++ b/frontend/src/components/HatchPage.jsx
@@ -10,7 +10,7 @@ export default function HatchPage() {
 
   useEffect(() => {
     const timer1 = setTimeout(() => setShowPet(true), 2000)
-    const timer2 = setTimeout(() => navigate('/', { replace: true }), 3500)
+    const timer2 = setTimeout(() => navigate('/map', { replace: true }), 3500)
     return () => {
       clearTimeout(timer1)
       clearTimeout(timer2)

--- a/frontend/src/components/MapPage.jsx
+++ b/frontend/src/components/MapPage.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react'
+import mapImage from '../../../Assets/Modes/Journeys/mapa.png'
+import heroImage from '../../../Assets/Mons/CriaturaSombria/criaturasombria.png'
+
+export default function MapPage() {
+  const [pet, setPet] = useState(null)
+  const [position, setPosition] = useState({ x: 50, y: 50 })
+
+  useEffect(() => {
+    const storedPet = window.api?.getPreference
+      ? window.api.getPreference('pet')
+      : localStorage.getItem('pet')
+    if (storedPet) {
+      try {
+        setPet(typeof storedPet === 'string' ? JSON.parse(storedPet) : storedPet)
+      } catch {
+        setPet(null)
+      }
+    }
+  }, [])
+
+  const handleMapClick = (e) => {
+    const rect = e.currentTarget.getBoundingClientRect()
+    const x = ((e.clientX - rect.left) / rect.width) * 100
+    const y = ((e.clientY - rect.top) / rect.height) * 100
+    setPosition({ x, y })
+  }
+
+  return (
+    <div className="w-full h-full flex items-center justify-center">
+      <div
+        className="relative"
+        style={{ width: '768px', height: '512px' }}
+        onClick={handleMapClick}
+      >
+        <img src={mapImage} alt="Mapa" className="w-full h-full object-cover" />
+        <img
+          src={heroImage}
+          alt={pet?.name || 'Personagem'}
+          className="absolute w-8 h-8"
+          style={{
+            left: `${position.x}%`,
+            top: `${position.y}%`,
+            transform: 'translate(-50%, -50%)',
+          }}
+        />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create MapPage for showing the initial map and placing the character
- navigate to `/map` once pet hatches
- register MapPage route in the app

## Testing
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687da6904304832a8315d0e18dcc5e4e