### PR TITLE
Add TMJ map loader API

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -42,7 +42,7 @@ if (!app.requestSingleInstanceLock()) {
 }
 
 let win: BrowserWindow | null = null
-const preload = path.join(__dirname, '../preload/index.mjs')
+const preload = path.join(__dirname, 'preload.js')
 const indexHtml = path.join(RENDERER_DIST, 'index.html')
 
 async function createWindow() {
@@ -56,12 +56,8 @@ async function createWindow() {
     autoHideMenuBar: true,
     webPreferences: {
       preload,
-      // Warning: Enable nodeIntegration and disable contextIsolation is not secure in production
-      // nodeIntegration: true,
-
-      // Consider using contextBridge.exposeInMainWorld
-      // Read more on https://www.electronjs.org/docs/latest/tutorial/context-isolation
-      // contextIsolation: false,
+      contextIsolation: true,
+      nodeIntegration: false,
     },
   })
 

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -1,4 +1,6 @@
 import { ipcRenderer, contextBridge } from 'electron'
+import fs from 'node:fs'
+import path from 'node:path'
 
 // --------- Expose some API to the Renderer process ---------
 contextBridge.exposeInMainWorld('ipcRenderer', {
@@ -25,6 +27,21 @@ contextBridge.exposeInMainWorld('ipcRenderer', {
 
 contextBridge.exposeInMainWorld('getPetAssets', (especie: string, elemento: string) => {
   return ipcRenderer.invoke('get-pet-assets', especie, elemento)
+})
+
+function loadMap(mapName: string) {
+  try {
+    const filePath = path.join(process.env.APP_ROOT!, 'tileset', `${mapName}.tmj`)
+    const content = fs.readFileSync(filePath, 'utf8')
+    return JSON.parse(content)
+  } catch (error) {
+    console.error('Failed to load map:', mapName, error)
+    return null
+  }
+}
+
+contextBridge.exposeInMainWorld('tmjAPI', {
+  loadMap,
 })
 
 // --------- Preload scripts loading ---------

--- a/src/demos/ipc.ts
+++ b/src/demos/ipc.ts
@@ -2,3 +2,10 @@
 window.ipcRenderer.on('main-process-message', (_event, ...args) => {
   console.log('[Receive Main-process message]:', ...args)
 })
+
+try {
+  const mapa = window.tmjAPI.loadMap('mapainicio')
+  console.log(mapa)
+} catch (error) {
+  console.error('Erro ao carregar mapa:', error)
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,4 +5,7 @@ interface Window {
   ipcRenderer: import('electron').IpcRenderer
   setCursorType?: (type: 'default' | 'pointer' | 'grab' | 'leave') => void
   getPetAssets: (especie: string, elemento: string) => Promise<{ animacaoEvolucao: string, assetPet: string | undefined }>
+  tmjAPI: {
+    loadMap: (mapName: string) => any
+  }
 }


### PR DESCRIPTION
## Summary
- expose `loadMap` via contextBridge in preload
- enable safe window options in the main process
- document new API in type declarations
- demonstrate map loading in renderer demo

## Testing
- `npm test` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e36aea734832a8a2e6c7557ddf3d2