### PR TITLE
Fix map loader call

### DIFF
--- a/src/components/GameMap.tsx
+++ b/src/components/GameMap.tsx
@@ -88,8 +88,8 @@ const GameMap = ({ playerSrc, petSrc }: Props) => {
     let cleanup: (() => void) | undefined
 
     ;(async () => {
-      const mapUrl = new URL('../../tileset/mapainicio.tmj', import.meta.url).href
-      const map: MapData = await fetch(mapUrl).then(res => res.json())
+      const map: MapData | null = await window.tmjAPI.loadMap('mapainicio')
+      if (!map) return
 
       const canvas = canvasRef.current
       if (!canvas) return


### PR DESCRIPTION
## Summary
- load map using the preload `tmjAPI` instead of fetch

## Testing
- `npm test` *(fails: vite not found)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687e40088c70832aa69991bd696d04b7