### PR TITLE
Fix preload script path

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -42,7 +42,10 @@ if (!app.requestSingleInstanceLock()) {
 }
 
 let win: BrowserWindow | null = null
-const preload = path.join(__dirname, '../preload.js')
+// Use the project root for the preload script instead of `dist-electron`
+// to avoid issues with missing files when running the application in
+// development.
+const preload = path.join(process.env.APP_ROOT!, 'preload.js')
 const indexHtml = path.join(RENDERER_DIST, 'index.html')
 
 async function createWindow() {


### PR DESCRIPTION
## Summary
- set preload script path to use project root

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e486ac248832a9de43b3a13cf314d