### PR TITLE
Fix preload resolution for packaged build

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,6 +6,10 @@ const fs = require('fs');
 const distIndex = path.join(__dirname, 'frontend', 'dist', 'index.html');
 const isDev = !fs.existsSync(distIndex);
 
+// Resolve the preload script using an absolute path so it works in
+// both development and packaged builds
+const preloadPath = path.join(app.getAppPath(), 'preload.js');
+
 let win;
 
 function createWindow() {
@@ -18,7 +22,7 @@ function createWindow() {
     frame: false,
     webPreferences: {
       contextIsolation: true,
-      preload: path.join(__dirname, 'preload.js')
+      preload: preloadPath
     }
   });
 


### PR DESCRIPTION
## Summary
- ensure the preload script path is resolved from the app path

## Testing
- `npm run dev` *(fails: concurrently not found)*
- `npm start` *(fails: electron executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e4d5b4770832aa6ddb443f01076a9