### PR TITLE
Add Mocha test setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@tailwindcss/postcss": "^4.1.11",
     "concurrently": "^9.2.0",
     "electron": "^29.4.6",
-    "wait-on": "^8.0.3"
+    "wait-on": "^8.0.3",
+    "mocha": "^10.4.0"
   },
   "dependencies": {
     "electron-store": "^8.2.0"

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+
+// Attempt to resolve the electron module. If it's not available, skip the tests.
+let electronAvailable = true;
+try {
+  require.resolve('electron');
+} catch (err) {
+  electronAvailable = false;
+}
+
+describe('main.js', function () {
+  it('loads without throwing', function () {
+    if (!electronAvailable) {
+      this.skip();
+    }
+    assert.doesNotThrow(() => {
+      require('../main.js');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a basic Mocha test that loads `main.js`
- install `mocha` as a dev dependency

## Testing
- `npm test` *(fails: mocha not found because dependencies aren't installed)*

------
https://chatgpt.com/codex/tasks/task_e_687e4e35b680832a92cd4c64c8001d37