### PR TITLE
feat: add app icon and improve start flow

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import IntroPage from './components/IntroPage'
 import QuestionnairePage from './components/QuestionnairePage'
 import ElementPage from './components/ElementPage'
 import HatchPage from './components/HatchPage'
+import LoadPet from './components/LoadPet'
 import TitleBar from './components/TitleBar'
 import CustomCursor from './components/CustomCursor'
 
@@ -13,13 +14,14 @@ export default function App() {
     <>
       <TitleBar />
       <CustomCursor />
-      <Routes>
-        <Route path="/" element={<HomeScreen />} />
-        <Route path="/intro" element={<IntroPage />} />
-        <Route path="/questions" element={<QuestionnairePage />} />
-        <Route path="/element" element={<ElementPage />} />
-        <Route path="/hatch" element={<HatchPage />} />
-      </Routes>
+        <Routes>
+          <Route path="/" element={<HomeScreen />} />
+          <Route path="/intro" element={<IntroPage />} />
+          <Route path="/questions" element={<QuestionnairePage />} />
+          <Route path="/element" element={<ElementPage />} />
+          <Route path="/hatch" element={<HatchPage />} />
+          <Route path="/load" element={<LoadPet />} />
+        </Routes>
     </>
   )
 }

--- a/frontend/src/components/HatchPage.jsx
+++ b/frontend/src/components/HatchPage.jsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import evolution from '../../../Assets/Mons/evolution.gif'
 import criaturaSombria from '../../../Assets/Mons/CriaturaSombria/criaturasombria.png'
 
 export default function HatchPage() {
   const navigate = useNavigate()
-  const { state } = useLocation()
   const [showPet, setShowPet] = useState(false)
 
   useEffect(() => {
@@ -18,7 +17,7 @@ export default function HatchPage() {
   }, [navigate])
 
   return (
-    <div className="character-creation-wrapper flex items-center justify-center h-full">
+    <div className="flex items-center justify-center h-full">
       {!showPet ? (
         <img src={evolution} alt="Hatching" className="w-64 h-64" />
       ) : (

--- a/frontend/src/components/HomeScreen.jsx
+++ b/frontend/src/components/HomeScreen.jsx
@@ -153,7 +153,11 @@ export default function HomeScreen() {
   const handleStart = () => {
     setShowLogo1(false)
     setShowLogo2(false)
-    navigate('/intro')
+    if (pet) {
+      navigate('/load')
+    } else {
+      navigate('/intro')
+    }
   }
 
   return (

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -250,7 +250,3 @@ img {
     justify-content: center;
     width: 500px;
 }
-
-.character-creation-wrapper {
-    width: 100%;
-}

--- a/main.js
+++ b/main.js
@@ -6,6 +6,9 @@ const fs = require('fs');
 const distIndex = path.join(__dirname, 'frontend', 'dist', 'index.html');
 const isDev = !fs.existsSync(distIndex);
 
+// Set application icon for taskbar and window
+const iconPath = path.join(__dirname, 'Assets', 'Logo', 'kadir11.png');
+
 let win;
 
 function createWindow() {
@@ -16,6 +19,7 @@ function createWindow() {
     minHeight: 600,
     backgroundColor: '#000000',
     frame: false,
+    icon: iconPath,
     webPreferences: {
       contextIsolation: true,
       preload: path.join(__dirname, 'preload.js')


### PR DESCRIPTION
## Summary
- restore previous hatch screen layout
- add application icon to Electron window
- route start to load existing pet if present

## Testing
- `npm run lint --prefix frontend`
- `npm test` *(fails: mocha: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68953946a94c832aae34bb20570d69d1